### PR TITLE
Resolves #3 Update controllercheck.sh

### DIFF
--- a/baseos/nobara-controller-config/controllercheck.sh
+++ b/baseos/nobara-controller-config/controllercheck.sh
@@ -15,6 +15,9 @@ internet_check() {
 install_drivers() {
       (
       	echo "# Installing xone and xpadneo packages..."
+        echo "20"; sleep 1
+        echo "# Installing dnf5 fixes."
+        dnf install -y "dnf5-command(builddep)"
         echo "50"; sleep 1
         pkexec bash -c 'usermod -aG pkg-build $USER && dnf4 install -y lpf-xone-firmware xone xpadneo && dnf4 remove -y xone-firmware'
         echo "# Packages installed, press OK to begin firmware installation."


### PR DESCRIPTION
The install script fails after migrating to dnf5 with the following error message:
 
```
"Unknown argument "builddep" for command "dnf5". Add "--help" for more information about the arguments.
It could be a command provided by a plugin, try: dnf install dnf5-command(builddep)"
```

I have not considered any possible consequences of adding this but it is the simplest fix to get it working.