### PR TITLE
Update controllercheck.sh

### DIFF
--- a/baseos/nobara-controller-config/controllercheck.sh
+++ b/baseos/nobara-controller-config/controllercheck.sh
@@ -17,7 +17,7 @@ install_drivers() {
       	echo "# Installing xone and xpadneo packages..."
         echo "20"; sleep 1
         echo "# Installing dnf5 fixes."
-        dnf install -y "dnf5-command(builddep)"
+        pkexec bash -c 'dnf install -y "dnf5-command(builddep)"'
         echo "50"; sleep 1
         pkexec bash -c 'usermod -aG pkg-build $USER && dnf4 install -y lpf-xone-firmware xone xpadneo && dnf4 remove -y xone-firmware'
         echo "# Packages installed, press OK to begin firmware installation."


### PR DESCRIPTION
Calling nobara-controller-config without sudo was causing it to fail as dnf does not automatically ask to escalate privileges.

I wrapped the install in pkexec to match the syntax of the other commands, this does cause an additional password prompt though. The command could probably be prepended to the main one but I was unsure of the preferred method.

Unrelated but I don't think the script actually works as intended.

`usermod -aG pkg-build $USER` requires the user to log out or log back in OR launch a new shell with `exec su -l $USER`.

The current script requires the user to run it three times. The first time basically setup usermod and then silently fails the script but prompts the user to reboot, the second time cleans everything up on an uninstall, and the third time actually installs the necessary firmware.