### PR TITLE
Add fix for Webkit empty window bug (fixes Lutris empty login windows)

### DIFF
--- a/baseos/setup/nobara-additions.patch
+++ b/baseos/setup/nobara-additions.patch
@@ -17,6 +17,8 @@ index 542add4..d40ad1d 100644
 +    export LIBVA_DRIVER_NAME=nvidia
 +    export MOZ_DISABLE_RDD_SANDBOX=1
 +    export EGL_PLATFORM=$XDG_SESSION_TYPE
++    # workaround for Webkit empty window bug
++    export WEBKIT_DISABLE_DMABUF_RENDERER=1
 +fi
 +fi
 +


### PR DESCRIPTION
Workaround for Webkit empty window problem, fixes Lutris Logins
Only needed for Nvidia cards
see also: [Lutris issue](https://github.com/lutris/lutris/issues/5242)
