### PR TITLE
Update steam-powerbuttond.spec

### DIFF
--- a/baseos/steam-powerbuttond/steam-powerbuttond.spec
+++ b/baseos/steam-powerbuttond/steam-powerbuttond.spec
@@ -1,6 +1,6 @@
 Name:           steam-powerbuttond
 Version:        0.0.git.1792.086c17c1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Steam Deck power button daemon
 
 License:        BSD
@@ -29,6 +29,7 @@ cd %{_builddir}
 
 cat << EOF >> %{_builddir}/98-steam-powerbuttond.preset
 enable steam-powerbuttond.service
+start steam-powerbuttond.service
 EOF
 
 git clone %{url} %{_builddir}/powerbuttond

--- a/baseos/steam-powerbuttond/steam-powerbuttond.spec
+++ b/baseos/steam-powerbuttond/steam-powerbuttond.spec
@@ -50,6 +50,8 @@ install -m 644 %{_builddir}/powerbuttond/steam-powerbuttond.service %{buildroot}
 udevadm control --reload-rules
 udevadm trigger
 %systemd_post steam-powerbuttond.service
+systemctl start steam-powerbuttond.service
+
 
 %preun
 %systemd_preun steam-powerbuttond.service


### PR DESCRIPTION
fixes  "Active: inactive (dead)" service status after enabling steam-powerbuttond.service in the .preset. adding start explicitly will properly start the service file after installation.