### PR TITLE
Jupiter fan control bump

### DIFF
--- a/baseos/jupiter-fan-control/fan_fix.patch
+++ b/baseos/jupiter-fan-control/fan_fix.patch
@@ -1,0 +1,20 @@
+diff --git usr/share/jupiter-fan-control/jupiter-config.yaml usr/share/jupiter-fan-control/jupiter-config.yaml
+index c907f3f..b036518 100644
+--- usr/share/jupiter-fan-control/jupiter-config.yaml
++++ usr/share/jupiter-fan-control/jupiter-config.yaml
+@@ -17,6 +17,8 @@ fan_min_time_on: 120
+ fan_gain: 10
+ ec_ramp_rate: 10
+ 
++dry_run: False
++
+ sensors:
+   - hwmon_name: amdgpu
+     nice_name: P_APU
+@@ -62,4 +64,4 @@ devices:
+     B: -531
+     C: 17394
+     T_threshold: 55
+-    # quadratic fit {{60, 2000}, {78, 3800}, {85, 5300}}
+\ No newline at end of file
++    # quadratic fit {{60, 2000}, {78, 3800}, {85, 5300}}

--- a/baseos/jupiter-fan-control/jupiter-fan-control.spec
+++ b/baseos/jupiter-fan-control/jupiter-fan-control.spec
@@ -48,6 +48,8 @@ cp -v usr/lib/systemd/system/jupiter-fan-control.service %{buildroot}%{_unitdir}
 udevadm control --reload-rules
 udevadm trigger
 %systemd_post jupiter-fan-control.service
+systemctl start steam-powerbuttond.service
+
 
 # Do before uninstallation
 %preun

--- a/baseos/jupiter-fan-control/jupiter-fan-control.spec
+++ b/baseos/jupiter-fan-control/jupiter-fan-control.spec
@@ -48,7 +48,6 @@ cp -v usr/lib/systemd/system/jupiter-fan-control.service %{buildroot}%{_unitdir}
 udevadm control --reload-rules
 udevadm trigger
 %systemd_post jupiter-fan-control.service
-systemctl start steam-powerbuttond.service
 
 
 # Do before uninstallation

--- a/baseos/jupiter-fan-control/jupiter-fan-control.spec
+++ b/baseos/jupiter-fan-control/jupiter-fan-control.spec
@@ -30,7 +30,6 @@ SteamOS 3.0 Steam Deck Fan Controller
 
 cat << EOF >> %{_builddir}/96-jupiter-fan-control.preset
 enable jupiter-fan-control.service
-start jupiter-fan-control.service
 EOF
 
 %build

--- a/baseos/jupiter-fan-control/jupiter-fan-control.spec
+++ b/baseos/jupiter-fan-control/jupiter-fan-control.spec
@@ -1,5 +1,5 @@
 Name:           jupiter-fan-control
-Version:        0.0.git.46.e9f304bf
+Version:        0.0.git.2027.5f33994e
 Release:        1%{?dist}
 Summary:        Steam Deck Fan Controller
 License:    	MIT
@@ -9,6 +9,8 @@ Source:        	https://gitlab.com/evlaV/%{name}/-/archive/main/%{name}-main.tar
 BuildArch:      noarch
 
 Patch0:         fedora.patch
+# Valve made a small typo (Thanks RodoMa92)
+Patch1:         fan_fix.patch
 
 Requires:       python3
 
@@ -21,19 +23,30 @@ SteamOS 3.0 Steam Deck Fan Controller
 %define debug_package %{nil}
 
 %prep
+
 %setup -n %{name}-main
 %patch 0 -p0
+%patch 1 -p0
+
+cat << EOF >> %{_builddir}/96-jupiter-fan-control.preset
+enable jupiter-fan-control.service
+start jupiter-fan-control.service
+EOF
 
 %build
 
 %install
 mkdir -p %{buildroot}%{_unitdir}/
 mkdir -p %{buildroot}%{_datadir}/
+mkdir -p %{buildroot}%{_presetdir}/
+install -m 644 %{_builddir}/96-jupiter-fan-control.preset %{buildroot}%{_presetdir}/
 cp -rv usr/share/* %{buildroot}%{_datadir}
 cp -v usr/lib/systemd/system/jupiter-fan-control.service %{buildroot}%{_unitdir}/jupiter-fan-control.service
 
 # Do post-installation
 %post
+udevadm control --reload-rules
+udevadm trigger
 %systemd_post jupiter-fan-control.service
 
 # Do before uninstallation
@@ -52,6 +65,7 @@ cp -v usr/lib/systemd/system/jupiter-fan-control.service %{buildroot}%{_unitdir}
 %{_datadir}/jupiter-fan-control/*-config.yaml
 %{_datadir}/jupiter-fan-control/PID.py
 %{_unitdir}/jupiter-fan-control.service
+%{_presetdir}/96-jupiter-fan-control.preset
 
 # Finally, changes from the latest release of your application are generated from
 # your project's Git history. It will be empty until you make first annotated Git tag.


### PR DESCRIPTION
bumps to latest version of jupiter-fan-control, and includes a typo fix to the source code from Bazzite. also implements the more consistent `systemctl start jupiter-fan-control.service` to guarantee the service starts after rpm install.