### PR TITLE
ds-inhibit: create new package imported from ublue

### DIFF
--- a/baseos/ds-inhibit/LICENSE
+++ b/baseos/ds-inhibit/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2022, Valve Software
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/baseos/ds-inhibit/ds-inhibit.spec
+++ b/baseos/ds-inhibit/ds-inhibit.spec
@@ -1,0 +1,59 @@
+Name:           ds-inhibit
+Version:        {{{ git_dir_version }}}
+Release:        1%{?dist}
+Summary:        DualShock 4/DualSense mouse inhibitor
+License:        BSD-2-Clause
+URL:            https://github.com/ublue-os/bazzite
+
+Source:         https://gitlab.com/evlaV/%{name}/-/archive/main/%{name}-main.tar.gz
+BuildArch:      noarch
+
+Patch0:         fedora.patch
+
+Requires:       python3
+Requires:       python3-inotify
+
+BuildRequires:  systemd-rpm-macros
+
+%description
+DualShock 4/DualSense mouse inhibitor
+
+# Disable debug packages
+%define debug_package %{nil}
+
+%prep
+%setup -n %{name}-main
+%patch 0
+chmod +x ds_inhibit.py
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_bindir}/
+mkdir -p %{buildroot}%{_unitdir}/
+cp -v ds_inhibit.py %{buildroot}%{_bindir}/ds-inhibit
+cp -v systemd.service %{buildroot}%{_unitdir}/ds-inhibit.service
+
+# Do post-installation
+%post
+%systemd_post ds-inhibit.service
+
+# Do before uninstallation
+%preun
+%systemd_preun ds-inhibit.service
+
+# Do after uninstallation
+%postun
+%systemd_postun_with_restart ds-inhibit.service
+
+# This lists all the files that are included in the rpm package and that
+# are going to be installed into target system where the rpm is installed.
+%files
+%license LICENSE
+%{_bindir}/ds-inhibit
+%{_unitdir}/ds-inhibit.service
+
+# Finally, changes from the latest release of your application are generated from
+# your project's Git history. It will be empty until you make first annotated Git tag.
+%changelog
+{{{ git_dir_changelog }}}

--- a/baseos/ds-inhibit/fedora.patch
+++ b/baseos/ds-inhibit/fedora.patch
@@ -1,0 +1,8 @@
+--- ds_inhibit.py
++++ ds_inhibit.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ # SPDX-License-Identifier: BSD-2-Clause
+ # vim:ts=4:sw=4:et
+ #


### PR DESCRIPTION
import the `.spec` and the `fedora.patch` file from Bazzite to allow `ds-inhibit` to be accessible in Nobara, doesn't need to be included and active out of the box but it would be nice to have in the repos for Steam Deck users