### PR TITLE
Bump jupiter-hw-support.spec version

### DIFF
--- a/baseos/jupiter-hw-support/fedora.patch
+++ b/baseos/jupiter-hw-support/fedora.patch
@@ -188,16 +188,6 @@ index 9e08cd6..189c805 100755
  
  set -eu
  
-diff --git a/usr/bin/steamos-polkit-helpers/steamos-retrigger-automounts b/usr/bin/steamos-polkit-helpers/steamos-retrigger-automounts
-index 4e92b57..2a5bfc4 100755
---- a/usr/bin/steamos-polkit-helpers/steamos-retrigger-automounts
-+++ b/usr/bin/steamos-polkit-helpers/steamos-retrigger-automounts
-@@ -1,4 +1,4 @@
--#!/bin/bash
-+#!/usr/bin/sh
- 
- # Helper to send reload to all active steamos-automount services, via pkexec if necessary/allowed
- 
 diff --git a/usr/bin/steamos-polkit-helpers/steamos-select-branch b/usr/bin/steamos-polkit-helpers/steamos-select-branch
 index 1b1d6c1..73f8547 100755
 --- a/usr/bin/steamos-polkit-helpers/steamos-select-branch

--- a/baseos/jupiter-hw-support/jupiter-hw-support.spec
+++ b/baseos/jupiter-hw-support/jupiter-hw-support.spec
@@ -1,6 +1,6 @@
 Name:           jupiter-hw-support
 Version:        0.0.git.1256.484fa801
-Release:        22%{?dist}
+Release:        23%{?dist}
 Summary:        Steam Deck Hardware Support Package
 License:        MIT
 URL:            https://github.com/nobara-project/steamdeck-edition-packages
@@ -34,6 +34,11 @@ SteamOS 3.0 Steam Deck Hardware Support Package
 
 %prep
 %autosetup -p1 -n %{name}
+cd %{_builddir}
+cat << EOF >> %{_builddir}/96-jupiter-hw-support.preset
+enable jupiter-biosupdate.service
+enable jupiter-controller-update.service
+EOF
 
 %build
 
@@ -41,10 +46,12 @@ SteamOS 3.0 Steam Deck Hardware Support Package
 export QA_RPATHS=0x0003
 mkdir -p %{buildroot}%{_datadir}/
 mkdir -p %{buildroot}%{_unitdir}/
+mkdir -p %{buildroot}%{_presetdir}/
 mkdir -p %{buildroot}%{_bindir}/
 mkdir -p %{buildroot}%{_libexecdir}/
 mkdir -p %{buildroot}%{_sysconfdir}/
 mkdir -p %{buildroot}%{_prefix}/lib/hwsupport/
+install -m 644 %{_builddir}/96-jupiter-hw-support.preset %{buildroot}%{_presetdir}/
 cp -rv usr/share/* %{buildroot}%{_datadir}
 cp -rv usr/lib/systemd/system/* %{buildroot}%{_unitdir}/
 cp usr/lib/hwsupport/power-button-handler.py %{buildroot}%{_prefix}/lib/hwsupport/power-button-handler.py
@@ -109,6 +116,7 @@ grub2-mkconfig -o /boot/grub2/grub.cfg
 %{_datadir}/polkit-1/rules.d/org.valve.steamos.rules
 %{_datadir}/steamos/steamos-cursor-config
 %{_datadir}/steamos/steamos-cursor.png
+%{_presetdir}/96-jupiter-hw-support.preset
 
 # Finally, changes from the latest release of your application are generated from
 # your project's Git history. It will be empty until you make first annotated Git tag.

--- a/baseos/jupiter-hw-support/jupiter-hw-support.spec
+++ b/baseos/jupiter-hw-support/jupiter-hw-support.spec
@@ -66,6 +66,13 @@ cp -rv etc/* %{buildroot}%{_sysconfdir}
 sed -i 's@steamos-cursor.png@usr/share/steamos/steamos-cursor.png@g' usr/share/steamos/steamos-cursor-config
 xcursorgen usr/share/steamos/steamos-cursor-config %{buildroot}%{_datadir}/icons/steam/cursors/default
 
+#Do pre-installation
+%pre
+# Check if the file exists and remove it
+if [ -f /usr/bin/steamos-polkit-helpers/steamos-retrigger-automounts ]; then
+    rm -f /usr/bin/steamos-polkit-helpers/steamos-retrigger-automounts
+fi
+
 # Do post-installation
 %post
 %systemd_post jupiter-biosupdate.service

--- a/baseos/jupiter-hw-support/jupiter-hw-support.spec
+++ b/baseos/jupiter-hw-support/jupiter-hw-support.spec
@@ -66,7 +66,7 @@ cp -rv etc/* %{buildroot}%{_sysconfdir}
 sed -i 's@steamos-cursor.png@usr/share/steamos/steamos-cursor.png@g' usr/share/steamos/steamos-cursor-config
 xcursorgen usr/share/steamos/steamos-cursor-config %{buildroot}%{_datadir}/icons/steam/cursors/default
 
-#Do pre-installation
+# Do pre-installation
 %pre
 # Check if the file exists and remove it
 if [ -f /usr/bin/steamos-polkit-helpers/steamos-retrigger-automounts ]; then


### PR DESCRIPTION
pairs with https://github.com/Nobara-Project/steamdeck-edition-packages/pull/1

bumps `jupiter-hw-support` release version to account for new controller firmware, gets rid of `steamos-retrigger-automounts` to match Valve's latest commit, adds .preset for `jupiter-biosupdate.service` and `jupiter-controller-update.service` in line with the .preset for `steam-powerbuttond.service` or else new firmware for the Deck will not get installed automatically in the background.