### PR TITLE
Update .spec and modules to match current xone release version

### DIFF
--- a/baseos/xone/modules-load-d-xone.conf
+++ b/baseos/xone/modules-load-d-xone.conf
@@ -1,7 +1,7 @@
 xone_dongle
-xone_gip-bus
+xone_gip
 xone_gip-chatpad
-xone_gip-common
 xone_gip-gamepad
 xone_gip-headset
 xone_wired
+xone_gip-guitar

--- a/baseos/xone/xone.spec
+++ b/baseos/xone/xone.spec
@@ -4,12 +4,12 @@
 %endif
 
 Name:     xone
-Version:  0.2
-Release:  5%{?dist}
+Version:  0.3
+Release:  1%{?dist}
 Summary:  Linux kernel driver for Xbox One and Xbox Series X|S accessories 
 License:  GPLv2
 URL:      https://github.com/medusalix/xone
-Source0:  %{url}/archive/refs/heads/%{name}-master.tar.gz
+Source0:  %{url}/archive/refs/heads/master.tar.gz
 Source1:  modules-load-d-%{name}.conf
 
 BuildRequires:  gcc


### PR DESCRIPTION
I have changed Source0 from `xone-master` to `master` in order to be compatible with `spectool -g xone.spec` from the readme, otherwise you get an error about the archive not existing while running the command. Let me know if you'd like me to rework it to pull specific commit hashes instead, but I figured best to leave it alone for now.

a .src.rpm for these changes are available here: https://download.copr.fedorainfracloud.org/results/matte-schwartz/random-testing/fedora-39-x86_64/06967686-xone/