### PR TITLE
add ally N-KEY to extest preload list

### DIFF
--- a/appstream/steam/steam.spec
+++ b/appstream/steam/steam.spec
@@ -5,7 +5,7 @@
 
 Name:           steam
 Version:        1.0.0.78
-Release:        12%{?dist}
+Release:        13%{?dist}
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT

--- a/appstream/steam/wayland-extest.patch
+++ b/appstream/steam/wayland-extest.patch
@@ -22,7 +22,7 @@ index 04c98b9..9257060 100755
  # Use wayland compatible libextest
 -export LD_PRELOAD=/usr/lib/steam/libextest.so
 +if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
-+  if [[ ! -z $(lsusb | grep '28de' | grep '1205') ]]; then
++  if [[ ! -z $(lsusb | grep '28de' | grep '1205') ]] || [[ ! -z $(lsusb | grep '0b05' | grep '1abe') ]]; then
 +    export LD_PRELOAD=/usr/lib/steam/libextest.so
 +  fi
 +fi


### PR DESCRIPTION
rogue-enemy, the default ootb input control method for ROG Ally, needs extest preloaded to show the desktop cursor.

at the request of several Nobara Ally users, I will be creating a separate PR to import and swap over to using [hhd](https://copr.fedorainfracloud.org/coprs/hhd-dev/hhd/), which has a different type of controller mode switch between desktop and controller modes, as the new default.