### PR TITLE
import handheld-daemon and consider setting as new default input for non-Deck handhelds

### DIFF
--- a/baseos/HandyGCCS/HandyGCCS.spec
+++ b/baseos/HandyGCCS/HandyGCCS.spec
@@ -13,6 +13,7 @@ BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools
+Conflicts:      hhd
 
 %description
 Handheld Game Console Controller Support (Handy Geeks) for Linux

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -1,6 +1,6 @@
 Name:           hhd
 Version:        1.1.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Handheld Daemon, a tool for configuring handheld devices.
 
 License:        MIT
@@ -30,8 +30,8 @@ Handheld Daemon is a project that aims to provide utilities for managing handhel
 %prep
 %autosetup -n %{name}-%{version}
 
-cat << EOF >> %{_builddir}/97-hhd@.preset
-enable hhd@.service
+cat << EOF >> %{_builddir}/94-%{name}@.preset
+enable %{name}@.service
 EOF
 
 %build
@@ -41,18 +41,18 @@ EOF
 %{python3} -m installer --destdir="%{buildroot}" dist/*.whl
 mkdir -p %{buildroot}%{_presetdir}/
 mkdir -p %{buildroot}%{_udevrulesdir}
-install -m644 usr/lib/udev/rules.d/83-%{name}.rules %{buildroot}%{_udevrulesdir}/83-%{name}.rules
 mkdir -p %{buildroot}%{_unitdir}
+install -m644 usr/lib/udev/rules.d/83-%{name}.rules %{buildroot}%{_udevrulesdir}/83-%{name}.rules
+install -m 644 %{_builddir}/94-%{name}@.preset %{buildroot}%{_presetdir}/
 install -m644 usr/lib/systemd/system/%{name}@.service %{buildroot}%{_unitdir}/%{name}@.service
-install -m 644 %{_builddir}/97-hhd@.preset %{buildroot}%{_presetdir}/
 
 %post
 udevadm control --reload-rules
 udevadm trigger
-%systemd_post hhd@.service
+%systemd_post %{name}@.service
 
 %preun
-%systemd_preun hhd@.service
+%systemd_preun %{name}@.service
 
 %files
 %doc readme.md
@@ -61,5 +61,5 @@ udevadm trigger
 %{python3_sitelib}/%{name}*
 %{_udevrulesdir}/83-%{name}.rules
 %{_unitdir}/%{name}@.service
-%{_presetdir}/97-hhd@.preset
+%{_presetdir}/94-%{name}@.preset
 

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -29,7 +29,7 @@ Handheld Daemon is a project that aims to provide utilities for managing handhel
 %prep
 %autosetup -n %{name}-%{version}
 
-cat << EOF >> %{_builddir}/99-hhd.preset
+cat << EOF >> %{_builddir}/97-hhd@.preset
 enable hhd@.service
 EOF
 
@@ -43,6 +43,15 @@ mkdir -p %{buildroot}%{_udevrulesdir}
 install -m644 usr/lib/udev/rules.d/83-%{name}.rules %{buildroot}%{_udevrulesdir}/83-%{name}.rules
 mkdir -p %{buildroot}%{_unitdir}
 install -m644 usr/lib/systemd/system/%{name}@.service %{buildroot}%{_unitdir}/%{name}@.service
+install -m 644 %{_builddir}/97-hhd@.preset %{buildroot}%{_presetdir}/
+
+%post
+udevadm control --reload-rules
+udevadm trigger
+%systemd_post hhd@.service
+
+%preun
+%systemd_preun hhd@.service
 
 %files
 %doc readme.md
@@ -51,5 +60,5 @@ install -m644 usr/lib/systemd/system/%{name}@.service %{buildroot}%{_unitdir}/%{
 %{python3_sitelib}/%{name}*
 %{_udevrulesdir}/83-%{name}.rules
 %{_unitdir}/%{name}@.service
-%{_presetdir}/99-hhd@.preset
+%{_presetdir}/97-hhd@.preset
 

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -19,6 +19,7 @@ Requires:       python3
 Requires:       python3-evdev
 Requires:       python3-rich
 Requires:       python3-yaml
+Requires:       python3-setuptools
 Conflicts:      HandyGCCS
 Conflicts:      lgcd
 Conflicts:      rogue-enemy

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -29,6 +29,10 @@ Handheld Daemon is a project that aims to provide utilities for managing handhel
 %prep
 %autosetup -n %{name}-%{version}
 
+cat << EOF >> %{_builddir}/99-hhd.preset
+enable hhd@.service
+EOF
+
 %build
 %{python3} -m build --wheel --no-isolation
 

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -38,6 +38,7 @@ EOF
 
 %install
 %{python3} -m installer --destdir="%{buildroot}" dist/*.whl
+mkdir -p %{buildroot}%{_presetdir}/
 mkdir -p %{buildroot}%{_udevrulesdir}
 install -m644 usr/lib/udev/rules.d/83-%{name}.rules %{buildroot}%{_udevrulesdir}/83-%{name}.rules
 mkdir -p %{buildroot}%{_unitdir}
@@ -50,3 +51,5 @@ install -m644 usr/lib/systemd/system/%{name}@.service %{buildroot}%{_unitdir}/%{
 %{python3_sitelib}/%{name}*
 %{_udevrulesdir}/83-%{name}.rules
 %{_unitdir}/%{name}@.service
+%{_presetdir}/99-hhd@.preset
+

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -1,0 +1,48 @@
+Name:           hhd
+Version:        1.1.4
+Release:        1%{?dist}
+Summary:        Handheld Daemon, a tool for configuring handheld devices.
+
+License:        MIT
+URL:            https://github.com/hhd-dev/hhd
+Source:        	https://pypi.python.org/packages/source/h/%{name}/%{name}-%{version}.tar.gz   
+
+BuildArch:      noarch
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  python3-devel
+BuildRequires:  python3-build
+BuildRequires:  python3-installer
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-wheel
+
+Requires:       python3
+Requires:       python3-evdev
+Requires:       python3-rich
+Requires:       python3-yaml
+Conflicts:      HandyGCCS
+Conflicts:      lgcd
+Conflicts:      rogue-enemy
+
+%description
+Handheld Daemon is a project that aims to provide utilities for managing handheld devices. With features ranging from TDP controls, to controller remappings, and gamescope session management. This will be done through a plugin system and an HTTP(/d-bus?) daemon, which will expose the settings of the plugins in a UI agnostic way.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%{python3} -m build --wheel --no-isolation
+
+%install
+%{python3} -m installer --destdir="%{buildroot}" dist/*.whl
+mkdir -p %{buildroot}%{_udevrulesdir}
+install -m644 usr/lib/udev/rules.d/83-%{name}.rules %{buildroot}%{_udevrulesdir}/83-%{name}.rules
+mkdir -p %{buildroot}%{_unitdir}
+install -m644 usr/lib/systemd/system/%{name}@.service %{buildroot}%{_unitdir}/%{name}@.service
+
+%files
+%doc readme.md
+%license LICENSE
+%{_bindir}/%{name}*
+%{python3_sitelib}/%{name}*
+%{_udevrulesdir}/83-%{name}.rules
+%{_unitdir}/%{name}@.service

--- a/baseos/lgcd/lgcd.spec
+++ b/baseos/lgcd/lgcd.spec
@@ -23,6 +23,7 @@ Recommends:     steam gamescope-session
 Provides:       lgcd
 Conflicts:      rogue-enemy
 Conflicts:      HandyGCCS
+Conflicts:      hhd
 
 %description
 Convert Lenovo Legion GO input to DualShock4 and allows mode switching with a long CC press

--- a/baseos/rogue-enemy/rogue-enemy.spec
+++ b/baseos/rogue-enemy/rogue-enemy.spec
@@ -21,6 +21,7 @@ Recommends:     steam gamescope-session
 Provides:       rogue-enemy
 Conflicts:      lgcd
 Conflicts:      HandyGCCS
+Conflicts:      hhd
 
 %description
 Convert ROG Ally input to DualShock4 and allows mode switching with a long CC press


### PR DESCRIPTION
After gathering feedback from current users, a shift from rogue-enemy (which is currently quite broken on 6.7, as confirmed by creator of rogue) to handheld-daemon has been requested. This PR has most of the components needed to execute this switch.

RPM and SRPMs for Nobara available for testing [here](https://drive.filen.io/f/a6a98cd1-6820-4cbf-b6eb-720f2ff48207#voIj4b0x1wK4O3wc1bCkoEN8EZZIDF8h). Would be interested in hearing feedback from LeGO too since it should be fully supported.

Submitting this as a standalone PR but would like your review for one question about `hhd` in `nobara-images` before making a PR there:

- hhd should eventually replace rogue-enemy in the nobara-images kickstart for deck. However, hhd as a package by default should also list `steam-powerbuttond` as a conflict in the .spec. I have not implemented this yet as it would affect Deck hardware too. perhaps needs a DMI check for certain handhelds (LeGO, Ally, etc) or a Deck exclusion of some sort?

as a sidenote, the maintainer for hhd is also available on Discord in the ROG ALLY Nobara Fixes thread (antheas)