### PR TITLE
hhd version bump with expanded device support

### DIFF
--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -1,5 +1,5 @@
 Name:           hhd
-Version:        1.3.3
+Version:        1.3.5
 Release:        1%{?dist}
 Summary:        Handheld Daemon, a tool for configuring handheld devices.
 
@@ -68,5 +68,5 @@ udevadm trigger
 %{_datadir}/polkit-1/actions/org.hhd.start.policy
 
 %changelog
-* Sun Feb 4 2024 Matthew Schwartz <njtransit215@gmail.com> 1.3.1-1
-- upgrades to new v1.3.3 release
+* Sun Feb 4 2024 Matthew Schwartz <njtransit215@gmail.com> 1.3.5-1
+- upgrades to new v1.3.5 release. support added for select devices from Ayaneo, AOKZOE, and GPD along with reduced system performance overhead.

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -1,5 +1,5 @@
 Name:           hhd
-Version:        1.3.1
+Version:        1.3.3
 Release:        1%{?dist}
 Summary:        Handheld Daemon, a tool for configuring handheld devices.
 
@@ -69,7 +69,4 @@ udevadm trigger
 
 %changelog
 * Sun Feb 4 2024 Matthew Schwartz <njtransit215@gmail.com> 1.3.1-1
-- upgrades to new v1.3.1 release
-
-* Sat Feb 3 2024 Matthew Schwartz <njtransit215@gmail.com> 1.2.1-1
-- upgrades to new v1.2.1 release, which includes support for new devices from AOKZOE and Ayaneo.
+- upgrades to new v1.3.3 release

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -1,5 +1,5 @@
 Name:           hhd
-Version:        1.2.1
+Version:        1.3.1
 Release:        1%{?dist}
 Summary:        Handheld Daemon, a tool for configuring handheld devices.
 
@@ -68,5 +68,8 @@ udevadm trigger
 %{_datadir}/polkit-1/actions/org.hhd.start.policy
 
 %changelog
+* Sun Feb 4 2024 Matthew Schwartz <njtransit215@gmail.com> 1.3.1-1
+- upgrades to new v1.3.1 release
+
 * Sat Feb 3 2024 Matthew Schwartz <njtransit215@gmail.com> 1.2.1-1
 - upgrades to new v1.2.1 release, which includes support for new devices from AOKZOE and Ayaneo.

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -42,6 +42,7 @@ mkdir -p %{buildroot}%{_udevrulesdir}
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_libexecdir}/
 mkdir -p %{buildroot}%{_sysconfdir}/xdg/autostart
+mkdir -p %{buildroot}%{_sysconfdir}/udev/hwdb.d/
 mkdir -p %{buildroot}%{_datadir}/polkit-1/actions/
 install -m644 usr/lib/udev/rules.d/83-%{name}.rules %{buildroot}%{_udevrulesdir}/83-%{name}.rules
 install -m644 usr/lib/systemd/system/%{name}@.service %{buildroot}%{_unitdir}/%{name}@.service

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -1,6 +1,6 @@
 Name:           hhd
-Version:        1.1.4
-Release:        7%{?dist}
+Version:        1.2
+Release:        1%{?dist}
 Summary:        Handheld Daemon, a tool for configuring handheld devices.
 
 License:        MIT
@@ -48,6 +48,7 @@ install -m644 usr/lib/systemd/system/%{name}@.service %{buildroot}%{_unitdir}/%{
 install -m775 usr/libexec/enable-hhd %{buildroot}%{_libexecdir}/enable-hhd
 install -m775 etc/xdg/autostart/hhd.desktop %{buildroot}%{_sysconfdir}/xdg/autostart/hhd.desktop
 install -m644 usr/share/polkit-1/actions/org.hhd.start.policy %{buildroot}%{_datadir}/polkit-1/actions/org.hhd.start.policy
+install -m644 usr/lib/udev/hwdb.d/83-%{name}.hwdb %{buildroot}%{_sysconfdir}/udev/hwdb.d/83-%{name}.hwdb
 
 %post
 udevadm control --reload-rules
@@ -62,4 +63,9 @@ udevadm trigger
 %{_unitdir}/%{name}@.service
 %{_libexecdir}/enable-hhd
 %{_sysconfdir}/xdg/autostart/hhd.desktop
+%{_sysconfdir}/udev/hwdb.d/83-%{name}.hwdb
 %{_datadir}/polkit-1/actions/org.hhd.start.policy
+
+%changelog
+* Sat Feb 3 2024 Matthew Schwartz <njtransit215@gmail.com> 1.2-1
+- upgrades to new v1.2 release, which includes support for new devices from AOKZOE and Ayaneo.

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -1,5 +1,5 @@
 Name:           hhd
-Version:        1.2
+Version:        1.2.1
 Release:        1%{?dist}
 Summary:        Handheld Daemon, a tool for configuring handheld devices.
 
@@ -67,5 +67,5 @@ udevadm trigger
 %{_datadir}/polkit-1/actions/org.hhd.start.policy
 
 %changelog
-* Sat Feb 3 2024 Matthew Schwartz <njtransit215@gmail.com> 1.2-1
-- upgrades to new v1.2 release, which includes support for new devices from AOKZOE and Ayaneo.
+* Sat Feb 3 2024 Matthew Schwartz <njtransit215@gmail.com> 1.2.1-1
+- upgrades to new v1.2.1 release, which includes support for new devices from AOKZOE and Ayaneo.

--- a/baseos/hhd/hhd.spec
+++ b/baseos/hhd/hhd.spec
@@ -1,5 +1,5 @@
 Name:           hhd
-Version:        1.3.5
+Version:        1.3.6
 Release:        1%{?dist}
 Summary:        Handheld Daemon, a tool for configuring handheld devices.
 
@@ -68,5 +68,5 @@ udevadm trigger
 %{_datadir}/polkit-1/actions/org.hhd.start.policy
 
 %changelog
-* Sun Feb 4 2024 Matthew Schwartz <njtransit215@gmail.com> 1.3.5-1
-- upgrades to new v1.3.5 release. support added for select devices from Ayaneo, AOKZOE, and GPD along with reduced system performance overhead.
+* Sun Feb 4 2024 Matthew Schwartz <njtransit215@gmail.com> 1.3.6-1
+- upgrades to new v1.3.6 release. support added for select devices from Ayaneo, AOKZOE, and GPD along with reduced system performance overhead.


### PR DESCRIPTION
Bumps to version 1.2.1 which includes support for a wider range of handheld PCs from Ayaneo, AOKZOE, and GPD Win 4 