### PR TITLE
hotfix: drop helldivers patch

### DIFF
--- a/baseos/mesa-vulkan-drivers/mesa-vulkan-drivers.spec
+++ b/baseos/mesa-vulkan-drivers/mesa-vulkan-drivers.spec
@@ -1,6 +1,6 @@
 %global _default_patch_fuzz 2
 
-%global commit e1afffe7fa7bd8e1cd1f7e58cfa2f33faf889628
+%global commit 75a940c949d5b4d8135531e1a9c5491c008910b5
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global build_timestamp %(date +"%Y%m%d")
 %global rel_build git.%{build_timestamp}.%{shortcommit}%{?dist}
@@ -93,7 +93,8 @@ Patch2: 25352.patch
 # https://gitlab.com/evlaV/mesa/
 Patch3: valve.patch
 
-Patch4: helldivers-2-gpu-hang-workaround-radv.patch
+# Disabled, causes GPU frequency to lock
+#Patch4: helldivers-2-gpu-hang-workaround-radv.patch
 
 Patch10:        gnome-shell-glthread-disable.patch
 


### PR DESCRIPTION
this drops the helldivers patch as it causes GPUs to lock to certain frequencies, causing 30-40% performance regression. 

also bumps version up to the latest which passed pipeline checks to avoid two versions with the same name on copr.