### PR TITLE
hotfix: build mangohud past reverted bad commit

### DIFF
--- a/baseos/mangohud/mangohud.spec
+++ b/baseos/mangohud/mangohud.spec
@@ -2,7 +2,7 @@
 ## (rpmautospec version 0.3.5)
 ## RPMAUTOSPEC: autorelease, autochangelog
 %define autorelease(e:s:pb:n) %{?-p:0.}%{lua:
-    release_number = 13;
+    release_number = 14;
     base_release_number = tonumber(rpm.expand("%{?-b*}%{!?-b:1}"));
     print(release_number + base_release_number - 1);
 }%{?-e:.%{-e*}}%{?-s:.%{-s*}}%{!?-n:%{?dist}}
@@ -20,7 +20,7 @@
 
 # NOBARA INTERNAL NOTE:
 # We are currently using upstream commit: 
-# a7a73afdadd045ed9235afae0b414c96808d24ee
+# 1baecfc493ecc32c9c2b14c025769485eb30de20
 
 Name:           mangohud
 Version:        0.7.1


### PR DESCRIPTION
commit https://github.com/flightlessmango/MangoHud/commit/7c7cb9a1dcf5aa09a9d09b1a6067c2611fe21020 was a revert due to regressions in commit https://github.com/flightlessmango/MangoHud/commit/7349a1cf29da3c8fd2f96b2941275e721eb3763e. we built off  https://github.com/flightlessmango/MangoHud/commit/a7a73afdadd045ed9235afae0b414c96808d24ee, which is prior to the revert. lets bring mangohud up to date to deal with the regression.