### PR TITLE
bump asusctl to 6.0.10

### DIFF
--- a/baseos/asusctl/asusctl.spec
+++ b/baseos/asusctl/asusctl.spec
@@ -21,13 +21,13 @@
 %endif
 
 %define specrelease %{?dist}
-%define pkg_release 2%{specrelease}
-%define vendor_upload_hash 15f94f447c4cec063923c8d356f47695
+%define pkg_release 3%{specrelease}
+%define vendor_upload_hash 9ed4417d95f99585d013a27d2aa6dce7
 
 # Use hardening ldflags.
 %global rustflags -Clink-arg=-Wl,-z,relro,-z,now
 Name:           asusctl
-Version:        5.0.10
+Version:        6.0.10
 Release: %{pkg_release}
 Summary:        Control fan speeds, LEDs, graphics modes, and charge levels for ASUS notebooks
 License:        MPLv2
@@ -36,8 +36,8 @@ Group:          System Environment/Kernel
 
 URL:            https://gitlab.com/asus-linux/asusctl
 Source:         %{URL}/-/archive/%{version}/%{name}-%{version}.tar.gz
-Source1:        %{URL}/uploads/%{vendor_upload_hash}/vendor_%{name}_.tar.xz
-Source2:        cargo_config
+Source1:        %{URL}/uploads/%{vendor_upload_hash}/vendor_%{name}_%{version}.tar.xz
+Source2:        cargo-config
 
 BuildRequires:  cargo
 BuildRequires:  rust-packaging
@@ -46,8 +46,15 @@ BuildRequires:  clang-devel
 BuildRequires:  cmake
 BuildRequires:  rust
 BuildRequires:  rust-std-static
+BuildRequires:  pkgconfig(expat)
+BuildRequires:  pkgconfig(gbm)
 BuildRequires:  pkgconfig(dbus-1)
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(libinput)
+BuildRequires:  pkgconfig(libseat)
 BuildRequires:  pkgconfig(libudev)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(libzstd)
 BuildRequires:  pkgconfig(gtk+-3.0)
 BuildRequires:  pkgconfig(gdk-3.0)
 BuildRequires:  desktop-file-utils

--- a/baseos/asusctl/cargo-config
+++ b/baseos/asusctl/cargo-config
@@ -1,0 +1,10 @@
+[source."git+https://github.com/slint-ui/slint.git"]
+git = "https://github.com/slint-ui/slint.git"
+replace-with = "vendored-sources"
+
+[source."git+https://gitlab.com/asus-linux/supergfxctl.git"]
+git = "https://gitlab.com/asus-linux/supergfxctl.git"
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"


### PR DESCRIPTION
adds official support for some '24 asus laptops which our kernel already has some of the patches for