### PR TITLE
Add scx-scheds toolkit

### DIFF
--- a/baseos/scx-scheds/scx-scheds.spec
+++ b/baseos/scx-scheds/scx-scheds.spec
@@ -1,0 +1,57 @@
+%define commit 643edb5431e12c74e1dbb598be07204dfe5d9469
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global build_timestamp %(date +"%Y%m%d")
+%global rel_build git.%{build_timestamp}.%{shortcommit}%{?dist}
+%define _disable_source_fetch 0
+
+Name:           scx-scheds
+Version:        1.0.1
+Release:        %{rel_build}
+Summary:        Sched_ext Schedulers and Tools
+
+License:        GPL=2.0
+URL:            https://github.com/sched-ext/scx
+Source0:        %{URL}/archive/%{commit}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  git
+BuildRequires:  meson >= 1.2
+BuildRequires:  python
+BuildRequires:  cargo
+BuildRequires:  rust
+BuildRequires:  clang >= 17
+BuildRequires:  llvm >= 17
+BuildRequires:  lld >= 17
+BuildRequires:  elfutils-libelf
+BuildRequires:  elfutils-libelf-devel
+BuildRequires:  zlib
+BuildRequires:  jq
+BuildRequires:  jq-devel
+BuildRequires:  systemd
+Requires:  elfutils-libelf
+Requires:  zlib
+Requires:  jq
+
+%description
+sched_ext is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them. This repository contains various scheduler implementations and support utilities.
+
+%prep
+%autosetup -n scx-%{commit}
+
+%build
+%meson \
+ -Dsystemd=enabled \
+ -Dopenrc=disabled \
+ -Dlibalpm=disabled
+%meson_build
+
+
+%install
+%meson_install
+
+
+%files
+%{_bindir}/*
+%{_prefix}/lib/systemd/system/scx.service
+%attr(0644,root,root) %config(noreplace) %{_sysconfdir}/default/scx
+%{_sysconfdir}/systemd/journald@sched-ext.conf


### PR DESCRIPTION
Add schedulers and toolkit that enables taking advantage of the new rust based CPU schedulers that our 6.10.2 has patched in support for.

https://github.com/sched-ext/scx