### PR TITLE
work around DCN issues in upstream AMD driver stack

### DIFF
--- a/baseos/kernel/6.10.2/dcn32-dcn301-dcn321-mpo-reverts.patch
+++ b/baseos/kernel/6.10.2/dcn32-dcn301-dcn321-mpo-reverts.patch
@@ -1,0 +1,105 @@
+From abfb30be0bebf7a56e38fabe6ed8affcb2cbabf4 Mon Sep 17 00:00:00 2001
+From: Matthew Schwartz <mattschwartz@gwu.edu>
+Date: Thu, 1 Aug 2024 19:05:58 -0700
+Subject: [PATCH 0/2] drm/amd/display: Collection of DCN reverts for Vangogh/7900XTX
+
+Seems like the entire MPO/MPC pipeline is borked in gamescope-session, 
+causing artifacts when the pipeline splits for overlay planes
+
+For now, let's just revert these ourselves while AMD investigates.
+
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠔⢠⣄⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡠⠄⠂⠉⢀⣀⠀⠀⠉⡀
+⠀⠀⠀⠀⠀⠀⢀⠀⠤⠀⠒⠀⠉⠀⠀⠀⠀⠀⡻⠋⢱⠀⠀⠇
+⠀⠀⡀⢀⠔⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⠒⠁⢀⠞⠀
+⢸⠁⠀⡎⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠄⠀⠀⢀⠴⠃⠀⠀
+⠈⠑⠦⠀⠀⠀⠀⠀⠤⢀⠀⠀⠀⠀⡠⠂⠀⢀⠖⠁⠀⠀⠀⠀
+⢀⠤⠒⠈⠉⠉⠀⠒⠂⠠⠌⠢⣀⣰⠀⠀⠀⡊⠀⢀⣀⡀⠀⠀
+⠣⡀⠀⢀⡀⠀⠀⠀⠀⠀⠀⢀⣸⠝⣤⡀⠀⠀⠉⠀⠈⣧⠒⣢
+⠀⠈⠒⠤⠬⣉⣀⠀⠀⠀⠉⢀⣙⠛⠾⡀⠉⠐⠒⠀⠐⠛⠂⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠉⠑⠢⢌⣀⠉⠐⠚⠀⠀⠀⠀⠀⠀⠀⠀
+
+
+Link: https://gitlab.freedesktop.org/drm/amd/-/issues/3441
+Signed-off-by: Matthew Schwartz <mattschwartz@gwu.edu>
+
+Matthew Schwartz (2):
+  Revert "drm/amd/display: Set MPC_SPLIT_DYNAMIC for DCN301"
+  Revert "drm/amd/display: reenable windowed mpo odm support on dcn32
+    and dcn321"
+
+ .../gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c    | 2 +-
+ drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c  | 1 -
+ .../gpu/drm/amd/display/dc/resource/dcn321/dcn321_resource.c    | 2 +-
+ 3 files changed, 2 insertions(+), 3 deletions(-)
+
+-- 
+2.45.2
+
+From 113462faa9fb383df2c11638f1c90656a054b2c8 Mon Sep 17 00:00:00 2001
+From: Matthew Schwartz <mattschwartz@gwu.edu>
+Date: Thu, 1 Aug 2024 19:03:53 -0700
+Subject: [PATCH 1/2] Revert "drm/amd/display: Set MPC_SPLIT_DYNAMIC for
+ DCN301"
+
+This reverts commit 75b204ee6cac4595cc663daf59b40162bbf411fb.
+---
+ .../gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c b/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
+index 7d04739c3ba1..a6193d4d00fa 100644
+--- a/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
+@@ -689,7 +689,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 	.disable_clock_gate = true,
+ 	.disable_pplib_clock_request = true,
+ 	.disable_pplib_wm_range = true,
+-	.pipe_split_policy = MPC_SPLIT_DYNAMIC,
++	.pipe_split_policy = MPC_SPLIT_AVOID,
+ 	.force_single_disp_pipe_split = false,
+ 	.disable_dcc = DCC_ENABLE,
+ 	.vsr_support = true,
+-- 
+2.45.2
+
+From abfb30be0bebf7a56e38fabe6ed8affcb2cbabf4 Mon Sep 17 00:00:00 2001
+From: Matthew Schwartz <mattschwartz@gwu.edu>
+Date: Thu, 1 Aug 2024 19:04:26 -0700
+Subject: [PATCH 2/2] Revert "drm/amd/display: reenable windowed mpo odm
+ support on dcn32 and dcn321"
+
+This reverts commit 34241dc665cf21bc628f1fea2249adb10010dfc0.
+---
+ drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c  | 1 -
+ .../gpu/drm/amd/display/dc/resource/dcn321/dcn321_resource.c    | 2 +-
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c b/drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c
+index 969658313fd6..934e5a3ac6bc 100644
+--- a/drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/resource/dcn32/dcn32_resource.c
+@@ -2219,7 +2219,6 @@ static bool dcn32_resource_construct(
+ 	dc->config.use_pipe_ctx_sync_logic = true;
+ 
+ 	dc->config.dc_mode_clk_limit_support = true;
+-	dc->config.enable_windowed_mpo_odm = true;
+ 	/* read VBIOS LTTPR caps */
+ 	{
+ 		if (ctx->dc_bios->funcs->get_lttpr_caps) {
+diff --git a/drivers/gpu/drm/amd/display/dc/resource/dcn321/dcn321_resource.c b/drivers/gpu/drm/amd/display/dc/resource/dcn321/dcn321_resource.c
+index 9a3cc0514a36..adde6c7b09f6 100644
+--- a/drivers/gpu/drm/amd/display/dc/resource/dcn321/dcn321_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/resource/dcn321/dcn321_resource.c
+@@ -1779,7 +1779,7 @@ static bool dcn321_resource_construct(
+ 	dc->caps.color.mpc.ocsc = 1;
+ 
+ 	dc->config.dc_mode_clk_limit_support = true;
+-	dc->config.enable_windowed_mpo_odm = true;
++	dc->config.enable_windowed_mpo_odm = false;
+ 	/* read VBIOS LTTPR caps */
+ 	{
+ 		if (ctx->dc_bios->funcs->get_lttpr_caps) {
+-- 
+2.45.2
+

--- a/baseos/kernel/6.10.2/kernel.spec
+++ b/baseos/kernel/6.10.2/kernel.spec
@@ -164,13 +164,13 @@ Summary: The Linux kernel
 %define specrpmversion 6.10.2
 %define specversion 6.10.2
 %define patchversion 6.10
-%define pkgrelease 200
+%define pkgrelease 201
 %define kversion 6
 %define tarfile_release 6.10.2
 # This is needed to do merge window version magic
 %define patchlevel 10
 # This allows pkg_release to have configurable %%{?dist} tag
-%define specrelease 200%{?buildid}%{?dist}
+%define specrelease 201%{?buildid}%{?dist}
 # This defines the kabi tarball version
 %define kabiversion 6.10.2
 
@@ -1047,6 +1047,8 @@ Patch410: bmi160_ayaneo.patch
 Patch501: 0001-Revert-PCI-Add-a-REBAR-size-quirk-for-Sapphire-RX-56.patch
 Patch502: 0001-acpi-proc-idle-skip-dummy-wait.patch
 Patch503: 0001-drm-amd-display-fix-corruption-with-high-refresh-rat.patch
+# workaround for https://gitlab.freedesktop.org/drm/amd/-/issues/3441 while AMD/Igalia invesigate
+Patch504: dcn32-dcn301-dcn321-mpo-reverts.patch
 
 # Allow to set custom USB pollrate for specific devices like so:
 # usbcore.interrupt_interval_override=045e:00db:16,1bcf:0005:1
@@ -1948,6 +1950,8 @@ ApplyOptionalPatch bmi160_ayaneo.patch
 ApplyOptionalPatch 0001-Revert-PCI-Add-a-REBAR-size-quirk-for-Sapphire-RX-56.patch
 ApplyOptionalPatch 0001-acpi-proc-idle-skip-dummy-wait.patch
 ApplyOptionalPatch 0001-drm-amd-display-fix-corruption-with-high-refresh-rat.patch
+# workaround for https://gitlab.freedesktop.org/drm/amd/-/issues/3441 while AMD/Igalia invesigate
+ApplyOptionalPatch dcn32-dcn301-dcn321-mpo-reverts.patch
 
 # Allow to set custom USB pollrate for specific devices like so:
 # usbcore.interrupt_interval_override=045e:00db:16,1bcf:0005:1


### PR DESCRIPTION
SteamOS will be reverting the change in dcn301 for now, I'm reverting the change in dcn32 and dc321 while AMD and Igalia investigate https://gitlab.freedesktop.org/drm/amd/-/issues/3441