### PR TITLE
Bump umu-launcher

### DIFF
--- a/baseos/umu-launcher/umu-launcher.spec
+++ b/baseos/umu-launcher/umu-launcher.spec
@@ -1,4 +1,4 @@
-%define commit 48741907db5dace31e6861b6be3a648a5cf1fb5b
+%define commit aced4416f8927696b73d4b75645c9c638fcb8792
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global build_timestamp %(date +"%Y%m%d")

--- a/baseos/umu-launcher/umu-launcher.spec
+++ b/baseos/umu-launcher/umu-launcher.spec
@@ -1,4 +1,4 @@
-%define commit 9b12f90b4e113275b5e8ea33a88674275bf3a1c8
+%define commit 48741907db5dace31e6861b6be3a648a5cf1fb5b
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global build_timestamp %(date +"%Y%m%d")

--- a/baseos/umu-launcher/umu-launcher.spec
+++ b/baseos/umu-launcher/umu-launcher.spec
@@ -6,7 +6,7 @@
 %global rel_build 1.%{build_timestamp}.%{shortcommit}%{?dist}
 
 Name:           umu-launcher
-Version:        1.0
+Version:        1.1
 Release:        %{rel_build}
 Summary:        A tool for launching non-steam games with proton
 


### PR DESCRIPTION
A bug was fixed in commit `aced4416f8927696b73d4b75645c9c638fcb8792` where the runtime would be updated repeatedly in subsequent launches after the runtime has already been updated due to the Cloudflare CDN cache not being purged immediately after a new runtime has been uploaded. 

See https://github.com/Open-Wine-Components/umu-launcher/issues/188 for the issue