### PR TITLE
Bump umu-launcher

### DIFF
--- a/baseos/umu-launcher/umu-launcher.spec
+++ b/baseos/umu-launcher/umu-launcher.spec
@@ -1,4 +1,4 @@
-%define commit e42043a26639cfb69d14c6945ecdebe2bb3c42fc
+%define commit 3e71418d937f054e04ff9173f18e57756c1fd9d6
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global build_timestamp %(date +"%Y%m%d")
@@ -6,7 +6,7 @@
 %global rel_build 1.%{build_timestamp}.%{shortcommit}%{?dist}
 
 Name:           umu-launcher
-Version:        1.1
+Version:        1.1.1
 Release:        %{rel_build}
 Summary:        A tool for launching non-steam games with proton
 

--- a/baseos/umu-launcher/umu-launcher.spec
+++ b/baseos/umu-launcher/umu-launcher.spec
@@ -1,4 +1,4 @@
-%define commit aced4416f8927696b73d4b75645c9c638fcb8792
+%define commit e42043a26639cfb69d14c6945ecdebe2bb3c42fc
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global build_timestamp %(date +"%Y%m%d")
@@ -31,6 +31,7 @@ BuildRequires:  python3
 Requires:	python
 Requires:	python3
 Requires:	python3-xlib
+Requires:	python3-filelock
 
 
 %description


### PR DESCRIPTION
- Fixes build by adding python3-filelock as a requirement, which was missing. Minimum version set in upstream is now 3.9, so it should meet the latest Fedora and its derivatives.
- [Updates umu-launcher to latest git](https://github.com/Open-Wine-Components/umu-launcher/commit/3e71418d937f054e04ff9173f18e57756c1fd9d6)