### PR TITLE
mock: Switch to dnf5 backend and enable ccache with default options

### DIFF
--- a/mock/nobara-40-i686.cfg
+++ b/mock/nobara-40-i686.cfg
@@ -1,3 +1,11 @@
+config_opts['plugin_conf']['ccache_enable'] = True
+config_opts['plugin_conf']['ccache_opts']['max_cache_size'] = '4G'
+config_opts['plugin_conf']['ccache_opts']['compress'] = None
+config_opts['plugin_conf']['ccache_opts']['dir'] = "%(cache_topdir)s/%(root)s/ccache/u%(chrootuid)s/"
+config_opts['plugin_conf']['ccache_opts']['hashdir'] = True
+config_opts['plugin_conf']['ccache_opts']['debug'] = False
+config_opts['plugin_conf']['ccache_opts']['show_stats'] = False
+
 config_opts['releasever'] = '40'
 config_opts['target_arch'] = 'i686'
 config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
@@ -13,7 +21,7 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 
 config_opts['dist'] = 'fc{{ releasever }}'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['package_manager'] = 'dnf'
+config_opts['package_manager'] = 'dnf5'
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:{{ releasever }}'
 
 config_opts['dnf.conf'] = """

--- a/mock/nobara-40-x86_64.cfg
+++ b/mock/nobara-40-x86_64.cfg
@@ -1,3 +1,11 @@
+config_opts['plugin_conf']['ccache_enable'] = True
+config_opts['plugin_conf']['ccache_opts']['max_cache_size'] = '4G'
+config_opts['plugin_conf']['ccache_opts']['compress'] = None
+config_opts['plugin_conf']['ccache_opts']['dir'] = "%(cache_topdir)s/%(root)s/ccache/u%(chrootuid)s/"
+config_opts['plugin_conf']['ccache_opts']['hashdir'] = True
+config_opts['plugin_conf']['ccache_opts']['debug'] = False
+config_opts['plugin_conf']['ccache_opts']['show_stats'] = False
+
 config_opts['releasever'] = '40'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
@@ -13,7 +21,7 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 
 config_opts['dist'] = 'fc{{ releasever }}'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['package_manager'] = 'dnf'
+config_opts['package_manager'] = 'dnf5'
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:{{ releasever }}'
 
 config_opts['dnf.conf'] = """


### PR DESCRIPTION
With these 2 things changed/added, my kernel compilations went from taking over 30 mins to just under 14.