### PR TITLE
Add orientation and headphone fixes for various Aya Neo devices

### DIFF
--- a/baseos/kernel/6.14/ayaneo-headset-fix.patch
+++ b/baseos/kernel/6.14/ayaneo-headset-fix.patch
@@ -1,0 +1,74 @@
+diff --git a/sound/pci/hda/patch_realtek.c b/sound/pci/hda/patch_realtek.c
+index ad66378d7321..02ce0be41a0c 100644
+--- a/sound/pci/hda/patch_realtek.c
++++ b/sound/pci/hda/patch_realtek.c
+@@ -6727,6 +6727,34 @@ static void alc294_gx502_toggle_output(struct hda_codec *codec,
+ 		alc_write_coef_idx(codec, 0x10, 0x0a20);
+ }
+ 
++static void alc269_fixup_headphone_volume_ayaneo_2(struct hda_codec *codec,
++					const struct hda_fixup *fix, int action)
++{
++	/* Pin 0x21: Some devices share 0x14 for headphones and speakers.
++	 * This fix will ensure these devices have volume controls. */
++	if (!is_jack_detectable(codec, 0x21))
++		return;
++
++	if (action == HDA_FIXUP_ACT_PRE_PROBE) {
++		static const hda_nid_t conn1[] = { 0x02 };
++		snd_hda_override_conn_list(codec, 0x14, ARRAY_SIZE(conn1), conn1);
++	}
++}
++
++static void alc269_fixup_headphone_volume_ayaneo_2s(struct hda_codec *codec,
++					const struct hda_fixup *fix, int action)
++{
++	/* Pin 0x15: Some devices share 0x14 for headphones and speakers.
++	 * This fix will ensure these devices have volume controls. */
++	if (!is_jack_detectable(codec, 0x15))
++		return;
++
++	if (action == HDA_FIXUP_ACT_PRE_PROBE) {
++		static const hda_nid_t conn1[] = { 0x02 };
++		snd_hda_override_conn_list(codec, 0x14, ARRAY_SIZE(conn1), conn1);
++	}
++}
++
+ static void alc294_fixup_gx502_hp(struct hda_codec *codec,
+ 					const struct hda_fixup *fix, int action)
+ {
+@@ -7532,6 +7560,8 @@ enum {
+ 	ALC269_FIXUP_DELL4_MIC_NO_PRESENCE,
+ 	ALC269_FIXUP_DELL4_MIC_NO_PRESENCE_QUIET,
+ 	ALC269_FIXUP_HEADSET_MODE,
++	ALC269_FIXUP_HEADSET_AYANEO_2,
++	ALC269_FIXUP_HEADSET_AYANEO_2S,
+ 	ALC269_FIXUP_HEADSET_MODE_NO_HP_MIC,
+ 	ALC269_FIXUP_ASPIRE_HEADSET_MIC,
+ 	ALC269_FIXUP_ASUS_X101_FUNC,
+@@ -9040,6 +9070,14 @@ static const struct hda_fixup alc269_fixups[] = {
+ 			{ 0x1b, 0x90170152 } /* use as internal speaker (back) */
+ 		}
+ 	},
++	[ALC269_FIXUP_HEADSET_AYANEO_2] = {
++		.type = HDA_FIXUP_FUNC,
++		.v.func = alc269_fixup_headphone_volume_ayaneo_2,
++	},
++	[ALC269_FIXUP_HEADSET_AYANEO_2S] = {
++		.type = HDA_FIXUP_FUNC,
++		.v.func = alc269_fixup_headphone_volume_ayaneo_2s,
++	},
+ 	[ALC299_FIXUP_PREDATOR_SPK] = {
+ 		.type = HDA_FIXUP_PINS,
+ 		.v.pins = (const struct hda_pintbl[]) {
+@@ -11005,6 +11043,10 @@ static const struct hda_quirk alc269_fixup_tbl[] = {
+ 	SND_PCI_QUIRK(0x2782, 0x1705, "MEDION E15433", ALC269VC_FIXUP_INFINIX_Y4_MAX),
+ 	SND_PCI_QUIRK(0x2782, 0x1707, "Vaio VJFE-ADL", ALC298_FIXUP_SPK_VOLUME),
+ 	SND_PCI_QUIRK(0x2782, 0x4900, "MEDION E15443", ALC233_FIXUP_MEDION_MTL_SPK),
++	SND_PCI_QUIRK(0x1f66, 0x0101, "AYANEO 2", ALC269_FIXUP_HEADSET_AYANEO_2),
++	SND_PCI_QUIRK(0x1f66, 0x0101, "GEEK", ALC269_FIXUP_HEADSET_AYANEO_2),
++	SND_PCI_QUIRK(0x1f66, 0x0103, "AYANEO 2S", ALC269_FIXUP_HEADSET_AYANEO_2S),
++	SND_PCI_QUIRK(0x1f66, 0x0103, "SuiPlay0X1", ALC269_FIXUP_HEADSET_AYANEO_2S),
+ 	SND_PCI_QUIRK(0x8086, 0x2074, "Intel NUC 8", ALC233_FIXUP_INTEL_NUC8_DMIC),
+ 	SND_PCI_QUIRK(0x8086, 0x2080, "Intel NUC 8 Rugged", ALC256_FIXUP_INTEL_NUC8_RUGGED),
+ 	SND_PCI_QUIRK(0x8086, 0x2081, "Intel NUC 10", ALC256_FIXUP_INTEL_NUC10),

--- a/baseos/kernel/6.14/kernel.spec
+++ b/baseos/kernel/6.14/kernel.spec
@@ -94,19 +94,23 @@ Patch8: ps-logitech-wheel.patch
 Patch9: amdgpu.ppfeaturemask-taint_warning.patch
 # fixes framerate control in gamescope
 Patch10: valve-gamescope-framerate-control-fixups.patch
+# fixes orientation on SuiPlay0X1
+Patch11: suiplay0x1-orientation-quirk.patch
+# fixes headphones on various Aya Neo devices
+Patch12: ayaneo-headset-fix.patch
 
 # temporary patches
 # fixes HAINAN amdgpu card not being bootable
 # https://gitlab.freedesktop.org/drm/amd/-/issues/1839
-Patch11: amdgpu-HAINAN-variant-fixup.patch
+Patch13: amdgpu-HAINAN-variant-fixup.patch
 # Allow to set custom USB pollrate for specific devices like so:
 # usbcore.interrupt_interval_override=045e:00db:16,1bcf:0005:1
 # useful for setting polling rate of wired PS4/PS5 controller to 1000Hz
 # https://github.com/KarsMulder/Linux-Pollrate-Patch
 # https://gitlab.com/GloriousEggroll/nobara-images/-/issues/64
-Patch12: 0001-Allow-to-set-custom-USB-pollrate-for-specific-device.patch
+Patch14: 0001-Allow-to-set-custom-USB-pollrate-for-specific-device.patch
 # Add xpadneo as patch instead of using dkms module
-Patch13: 0001-Add-xpadneo-bluetooth-hid-driver-module.patch
+Patch15: 0001-Add-xpadneo-bluetooth-hid-driver-module.patch
 
 %define __spec_install_post /usr/lib/rpm/brp-compress || :
 %define debug_package %{nil}
@@ -413,6 +417,8 @@ patch -p1 -i %{PATCH10}
 patch -p1 -i %{PATCH11}
 patch -p1 -i %{PATCH12}
 patch -p1 -i %{PATCH13}
+patch -p1 -i %{PATCH14}
+patch -p1 -i %{PATCH15}
 
 # Fetch the config and move it to the proper directory
 cp %{SOURCE1} .config

--- a/baseos/kernel/6.14/suiplay0x1-orientation-quirk.patch
+++ b/baseos/kernel/6.14/suiplay0x1-orientation-quirk.patch
@@ -1,0 +1,17 @@
+diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+index c554ad8f246b..3c686d7fca3c 100644
+--- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
++++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
+@@ -460,6 +460,12 @@ static const struct dmi_system_id orientation_data[] = {
+ 		 DMI_MATCH(DMI_PRODUCT_VERSION, "Blade3-10A-001"),
+ 		},
+ 		.driver_data = (void *)&lcd1600x2560_rightside_up,
++	}, {	/* Mysten Labs SuiPlay 0X1 (Rebranded AYANEO 2S) */
++		.matches = {
++		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "Mysten Labs, Inc."),
++		  DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "SuiPlay0X1"),
++		},
++		.driver_data = (void *)&lcd1200x1920_rightside_up,
+ 	}, {	/* Nanote UMPC-01 */
+ 		.matches = {
+ 		 DMI_MATCH(DMI_SYS_VENDOR, "RWC CO.,LTD"),


### PR DESCRIPTION
These patches include:
 - Orientation fix for SuiPlay0X1 (an upcoming device that is a rebranded Aya Neo 2S)
 - Headphone fixes for:
     - SuiPlay0X1
     - Aya Neo 2
     - Aya Neo 2S
     - Aya Neo Geek


All devices tested except for the Aya Neo Geek, but that patch has been part of the ChimeraOS kernel for ages without any reported issues.

The goal was to add support for the upcoming SuiPlay0X1 which is a rebranded Aya Neo 2S, but while doing that I figured I may as well add the fixes for the other devices known to work with these same patches.