### PR TITLE
bump inputplumber and use architecture-specific binary

### DIFF
--- a/baseos/inputplumber/inputplumber.spec
+++ b/baseos/inputplumber/inputplumber.spec
@@ -1,7 +1,7 @@
 %global _name   inputplumber
 
 Name:           inputplumber
-Version:        0.52.1
+Version:        0.55.3
 Release:        1%{?dist}
 Summary:        InputPlumber is an open source input routing and control daemon for Linux. It can be used to combine any number of input devices (like gamepads, mice, and keyboards) and translate their input to a variety of virtual device formats.
 
@@ -41,7 +41,7 @@ mkdir -p %{buildroot}/usr/share/inputplumber/devices
 mkdir -p %{buildroot}/usr/share/inputplumber/profiles
 mkdir -p %{buildroot}/usr/share/inputplumber/schema
 
-install -D -m 755 %{_builddir}/InputPlumber/target/release/inputplumber %{buildroot}/usr/bin/inputplumber
+install -D -m 755 %{_builddir}/InputPlumber/target/%{_arch}-unknown-linux-gnu/release/inputplumber %{buildroot}/usr/bin/inputplumber
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf %{buildroot}/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/lib/systemd/system/* %{buildroot}/usr/lib/systemd/system/
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/lib/udev/hwdb.d/59-inputplumber.hwdb %{buildroot}/usr/lib/udev/hwdb.d/59-inputplumber.hwdb


### PR DESCRIPTION
As of inputplumber v0.55.3, the built binary is placed in an architecture-specific directory. This change bumps inputplumber to version 0.55.3 and updates the binary path to use the architecture-specific location.

Related upstream commit:
https://github.com/ShadowBlip/InputPlumber/commit/e1a9627de279888eeed615a62defb0db0d0c29f8