### PR TITLE
update switcheroo-control discrete patch

### DIFF
--- a/baseos/switcheroo-control/69.patch
+++ b/baseos/switcheroo-control/69.patch
@@ -1,8 +1,9 @@
-From fd60ef83867d5f7a3a7ad484eae4851ac93b7885 Mon Sep 17 00:00:00 2001
+From 44046bfbcb30a19c45416113a2a82a4d17a1a998 Mon Sep 17 00:00:00 2001
 From: Jan200101 <sentrycraft123@gmail.com>
 Date: Mon, 14 Aug 2023 14:06:45 +0200
-Subject: [PATCH 1/9] main: update GPUs comment for dbus property
+Subject: [PATCH 01/13] main: update GPUs comment for dbus property
 
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
 ---
  src/net.hadess.SwitcherooControl.xml | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
@@ -22,9 +23,44 @@ index e52bc1a..59a8896 100644
      <property name="GPUs" type="aa{sv}" access="read"/>
  
 -- 
-GitLab
+2.49.0
 
 
+From 4f31415cb61a50c2bcba1510a7511518417d0970 Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Mon, 11 Sep 2023 15:21:46 +0200
+Subject: [PATCH 02/13] main: add Discrete key
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ .gitlab-ci.yml                     |   1 +
+ data/30-discrete-gpu.rules.in      |   3 +
+ data/meson.build                   |   7 ++
+ meson.build                        |   9 +++
+ meson_options.txt                  |  24 +++++++
+ src/discrete-detection/amdgpu.c    |  46 +++++++++++++
+ src/discrete-detection/meson.build |  18 +++++
+ src/discrete-detection/nouveau.c   | 105 +++++++++++++++++++++++++++++
+ src/meson.build                    |   4 +-
+ src/switcheroo-control.c           |  16 +++++
+ 10 files changed, 232 insertions(+), 1 deletion(-)
+ create mode 100644 data/30-discrete-gpu.rules.in
+ create mode 100644 src/discrete-detection/amdgpu.c
+ create mode 100644 src/discrete-detection/meson.build
+ create mode 100644 src/discrete-detection/nouveau.c
+
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+index a6aa3c7..a09fe20 100644
+--- a/.gitlab-ci.yml
++++ b/.gitlab-ci.yml
+@@ -3,6 +3,7 @@ image: fedora:rawhide
+ variables:
+   DEPENDENCIES: glib2-devel
+                 libgudev-devel
++                libdrm-devel
+                 gtk-doc
+                 gcc
+                 gcc-c++
 diff --git a/data/30-discrete-gpu.rules.in b/data/30-discrete-gpu.rules.in
 new file mode 100644
 index 0000000..a803ed4
@@ -319,7 +355,7 @@ index ab3a77d..da4267f 100644
 +
 +subdir('discrete-detection')
 diff --git a/src/switcheroo-control.c b/src/switcheroo-control.c
-index 591b4b7..39d1cf6 100644
+index abd8154..e407bfb 100644
 --- a/src/switcheroo-control.c
 +++ b/src/switcheroo-control.c
 @@ -31,6 +31,7 @@ typedef struct {
@@ -339,7 +375,7 @@ index 591b4b7..39d1cf6 100644
  
  		g_variant_builder_add (&builder, "a{sv}", &asv_builder);
  	}
-@@ -340,6 +343,18 @@ get_card_is_default (GUdevDevice *d)
+@@ -312,6 +315,18 @@ get_card_is_default (GUdevDevice *d)
  	return g_udev_device_get_sysfs_attr_as_boolean (parent, "boot_vga");
  }
  
@@ -358,7 +394,7 @@ index 591b4b7..39d1cf6 100644
  static CardData *
  get_card_data (GUdevClient *client,
  	       GUdevDevice *d)
-@@ -356,6 +371,7 @@ get_card_data (GUdevClient *client,
+@@ -328,6 +343,7 @@ get_card_data (GUdevClient *client,
  	data->name = get_card_name (d);
  	data->env = env;
  	data->is_default = get_card_is_default (d);
@@ -367,24 +403,25 @@ index 591b4b7..39d1cf6 100644
  	return data;
  }
 -- 
-GitLab
+2.49.0
 
 
-From 79d1769c7f9d1310d80b8f545c23c9a5d1c0a4c7 Mon Sep 17 00:00:00 2001
+From 1b115ed72e03ff1169cbfddd79ef10890baca133 Mon Sep 17 00:00:00 2001
 From: Jan200101 <sentrycraft123@gmail.com>
 Date: Tue, 12 Sep 2023 15:53:40 +0200
-Subject: [PATCH 3/9] tests: fix integration tests without UMockdev
+Subject: [PATCH 03/13] tests: fix integration tests without UMockdev
  `gi.require_version` throws ValueError if the dependency cannot be found
 
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
 ---
  tests/integration-test.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/tests/integration-test.py b/tests/integration-test.py
-index 997e1d5..c23d928 100755
+index d8dea16..e3dd996 100755
 --- a/tests/integration-test.py
 +++ b/tests/integration-test.py
-@@ -38,7 +38,7 @@ except ImportError as e:
+@@ -37,7 +37,7 @@ except ImportError as e:
  try:
      gi.require_version('UMockdev', '1.0')
      from gi.repository import UMockdev
@@ -394,16 +431,17 @@ index 997e1d5..c23d928 100755
      sys.exit(0)
  
 -- 
-GitLab
+2.49.0
 
 
-From ee544e7bc17c5ed084073ef5d7d9dbada1177d66 Mon Sep 17 00:00:00 2001
+From d933e96bdb15679ae7653f929461982aa66973ba Mon Sep 17 00:00:00 2001
 From: Jan200101 <sentrycraft123@gmail.com>
 Date: Tue, 12 Sep 2023 15:58:16 +0200
-Subject: [PATCH 4/9] tests: add tests for discrete detection with mock libs
+Subject: [PATCH 04/13] tests: add tests for discrete detection with mock libs
  Both tests have 4 different ways of testing: - Invalid Device - Unexpected
  Device - Non Discrete GPU (iGPU/APU) - Discrete GPU
 
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
 ---
  src/discrete-detection/meson.build            |  4 +-
  tests/discrete-detection/libdrm_amdgpu_mock.c | 57 +++++++++++++
@@ -672,14 +710,15 @@ index b0b7476..61ef00c 100644
 +
 +subdir('discrete-detection')
 -- 
-GitLab
+2.49.0
 
 
-From 7843d33eea5e9529ec3b2876b322e1329bcaf077 Mon Sep 17 00:00:00 2001
+From c102b643945dc076d881497dd2ca5865938f7053 Mon Sep 17 00:00:00 2001
 From: Jan200101 <sentrycraft123@gmail.com>
 Date: Tue, 12 Sep 2023 15:57:47 +0200
-Subject: [PATCH 5/9] main: remove leftover and fix typo
+Subject: [PATCH 05/13] main: remove leftover and fix typo
 
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
 ---
  meson_options.txt        | 2 +-
  src/switcheroo-control.c | 1 -
@@ -699,10 +738,10 @@ index b8d671a..c77fea8 100644
  
  option('gtk_doc',
 diff --git a/src/switcheroo-control.c b/src/switcheroo-control.c
-index 39d1cf6..84c7108 100644
+index e407bfb..0f6a548 100644
 --- a/src/switcheroo-control.c
 +++ b/src/switcheroo-control.c
-@@ -347,7 +347,6 @@ static gboolean
+@@ -319,7 +319,6 @@ static gboolean
  get_card_is_discrete (GUdevDevice *d)
  {
  	const char * const * tags;
@@ -711,14 +750,15 @@ index 39d1cf6..84c7108 100644
  	tags = g_udev_device_get_tags (d);
  	if (tags && g_strv_contains (tags, "switcheroo-discrete-gpu"))
 -- 
-GitLab
+2.49.0
 
 
-From dfa369b08c85bf878a2c5c15c02bd737303fed9a Mon Sep 17 00:00:00 2001
+From f764db4eb565c19ba14155791fbfced3fb5d34c8 Mon Sep 17 00:00:00 2001
 From: Jan200101 <sentrycraft123@gmail.com>
 Date: Tue, 12 Sep 2023 15:58:27 +0200
-Subject: [PATCH 6/9] main: move discrete dependencies out of main deps
+Subject: [PATCH 06/13] main: move discrete dependencies out of main deps
 
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
 ---
  src/discrete-detection/meson.build | 5 +++--
  src/meson.build                    | 2 +-
@@ -759,14 +799,15 @@ index da4267f..22d69e7 100644
  sources = [
    'info-cleanup.c',
 -- 
-GitLab
+2.49.0
 
 
-From 9e1e406d7f79da5868bd396b0cf005ca3d635772 Mon Sep 17 00:00:00 2001
+From d2ecc29469d5572fd171926c9d1dbb1b851c7b09 Mon Sep 17 00:00:00 2001
 From: Jan200101 <sentrycraft123@gmail.com>
 Date: Tue, 12 Sep 2023 17:12:00 +0200
-Subject: [PATCH 7/9] main: use glib for discrete command-line arguments
+Subject: [PATCH 07/13] main: use glib for discrete command-line arguments
 
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
 ---
  src/discrete-detection/amdgpu.c  | 29 ++++++++++++++++++++---------
  src/discrete-detection/nouveau.c | 29 ++++++++++++++++++++---------
@@ -896,16 +937,17 @@ index 0a1f220..1d61cbb 100644
  	{
  		case NV_DEVICE_INFO_V0_IGP:
 -- 
-GitLab
+2.49.0
 
 
-From 0bb08115acf7e9ed235f00df5bbcb5bc2316cea7 Mon Sep 17 00:00:00 2001
+From 462b09f02de37dfd2965d23cc7c4137bcf45a4ae Mon Sep 17 00:00:00 2001
 From: Jan200101 <sentrycraft123@gmail.com>
 Date: Wed, 14 Feb 2024 20:25:42 +0100
-Subject: [PATCH 8/9] main: add udev rule for i915 checking a lot of systems
+Subject: [PATCH 08/13] main: add udev rule for i915 checking a lot of systems
  has shown that the intel iGPU will always be available at `0000:00:02.0`.
  Using ID_PATH would have been cleaner, but I couldn't get it to work.
 
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
 ---
  data/30-discrete-gpu.rules.in | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
@@ -921,14 +963,15 @@ index a803ed4..f30f315 100644
 +DRIVERS=="nvidia", SUBSYSTEM=="drm", TAG+="switcheroo-discrete-gpu"
 +DRIVERS=="i915", SUBSYSTEM=="drm", DEVPATH!="/devices/pci0000:00/0000:00:02.0/drm/*", TAG+="switcheroo-discrete-gpu"
 -- 
-GitLab
+2.49.0
 
 
-From 4bf9412c2d5ddd1639ffe30fcccf824bba29b355 Mon Sep 17 00:00:00 2001
+From 55db3aeaeb962952881f73e94432f750cfb64fc8 Mon Sep 17 00:00:00 2001
 From: Jan200101 <sentrycraft123@gmail.com>
 Date: Thu, 15 Feb 2024 16:24:00 +0100
-Subject: [PATCH 9/9] main: use Discrete key in switcherooctl
+Subject: [PATCH 09/13] main: use Discrete key in switcherooctl
 
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
 ---
  src/switcherooctl.in | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
@@ -955,5 +998,338 @@ index 96c21cc..c0e3f07 100755
          return None
      else:
 -- 
-GitLab
+2.49.0
+
+
+From 4232c75fe41158bb5063d630d36b3ffd6a8a57ec Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Fri, 6 Sep 2024 22:31:56 +0200
+Subject: [PATCH 10/13] main: use new GPU list on uevent the amount of GPUs may
+ still be the same but underlying attributes may have changed On the ASUS TUF
+ Dash F15 running Fedora 40 6.10.7-200.fc40.x86_64 the udev tags are not
+ applied at the time switcheroo-control starts but at a later uevent they are
+ correct. Memory gets allocated anyways to check if the GPU count has changed,
+ so this shouldn't affect memory usage.
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ src/switcheroo-control.c | 16 ++++++----------
+ 1 file changed, 6 insertions(+), 10 deletions(-)
+
+diff --git a/src/switcheroo-control.c b/src/switcheroo-control.c
+index 0f6a548..01954c7 100644
+--- a/src/switcheroo-control.c
++++ b/src/switcheroo-control.c
+@@ -438,16 +438,12 @@ uevent_cb (GUdevClient *client,
+ 
+ 	cards = get_drm_cards (data);
+ 	num_gpus = cards->len;
+-	if (num_gpus != data->num_gpus) {
+-		g_debug ("GPUs added or removed (old: %d new: %d)",
+-			 data->num_gpus, num_gpus);
+-		g_ptr_array_free (data->cards, TRUE);
+-		data->cards = cards;
+-		data->num_gpus = cards->len;
+-		send_dbus_event (data);
+-	} else {
+-		g_ptr_array_free (cards, TRUE);
+-	}
++	g_debug ("GPUs updated (old: %d new: %d)",
++		 data->num_gpus, num_gpus);
++	g_ptr_array_free (data->cards, TRUE);
++	data->cards = cards;
++	data->num_gpus = cards->len;
++	send_dbus_event (data);
+ }
+ 
+ static void
+-- 
+2.49.0
+
+
+From ad09f908cc9e56cccfc946b285f2e7ddd014c587 Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Mon, 28 Apr 2025 21:41:47 +0200
+Subject: [PATCH 11/13] main: add xe discrete detection
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ data/30-discrete-gpu.rules.in      |  1 +
+ meson.build                        |  1 +
+ meson_options.txt                  |  6 +++
+ src/discrete-detection/meson.build |  9 +++++
+ src/discrete-detection/xe.c        | 63 ++++++++++++++++++++++++++++++
+ 5 files changed, 80 insertions(+)
+ create mode 100644 src/discrete-detection/xe.c
+
+diff --git a/data/30-discrete-gpu.rules.in b/data/30-discrete-gpu.rules.in
+index f30f315..ab60bf2 100644
+--- a/data/30-discrete-gpu.rules.in
++++ b/data/30-discrete-gpu.rules.in
+@@ -2,3 +2,4 @@ DRIVERS=="amdgpu", SUBSYSTEM=="drm", PROGRAM="@libexecdir@/check-discrete-amdgpu
+ DRIVERS=="nouveau", SUBSYSTEM=="drm", PROGRAM="@libexecdir@/check-discrete-nouveau $env{DEVNAME}", TAG+="switcheroo-discrete-gpu"
+ DRIVERS=="nvidia", SUBSYSTEM=="drm", TAG+="switcheroo-discrete-gpu"
+ DRIVERS=="i915", SUBSYSTEM=="drm", DEVPATH!="/devices/pci0000:00/0000:00:02.0/drm/*", TAG+="switcheroo-discrete-gpu"
++DRIVERS=="xe", SUBSYSTEM=="drm", PROGRAM="@libexecdir@/check-discrete-xe $env{DEVNAME}", TAG+="switcheroo-discrete-gpu"
+diff --git a/meson.build b/meson.build
+index b3aaf0c..31dfa95 100644
+--- a/meson.build
++++ b/meson.build
+@@ -23,6 +23,7 @@ gudev = dependency('gudev-1.0', version: '>= 232')
+ libdrm = dependency('libdrm', version: '>= 2.4.97', required: get_option('libdrm'))
+ libdrm_nouveau = dependency('libdrm_nouveau', version: '>= 2.4.97', required: get_option('libdrm_nouveau'))
+ libdrm_amdgpu = dependency('libdrm_amdgpu', version: '>= 2.4.97', required: get_option('libdrm_amdgpu'))
++drm_xe = cc.has_header('drm/xe_drm.h', required: get_option('drm_xe'))
+ 
+ systemd_systemunitdir = get_option('systemdsystemunitdir')
+ if systemd_systemunitdir == ''
+diff --git a/meson_options.txt b/meson_options.txt
+index c77fea8..058dbdd 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -45,3 +45,9 @@ option('libdrm_amdgpu',
+   type: 'feature',
+   value: 'auto'
+ )
++
++option('drm_xe',
++  description: 'Whether the kernel provided xe drm header should be used to probe Intel GPUs',
++  type: 'feature',
++  value: 'auto'
++)
+diff --git a/src/discrete-detection/meson.build b/src/discrete-detection/meson.build
+index 353316f..7e0b324 100644
+--- a/src/discrete-detection/meson.build
++++ b/src/discrete-detection/meson.build
+@@ -17,3 +17,12 @@ if libdrm.found() and libdrm_nouveau.found()
+     install_dir: libexecdir,
+   )
+ endif
++
++if drm_xe
++  xe_discrete = executable('check-discrete-xe',
++    files('xe.c'),
++    dependencies: deps,
++    install: true,
++    install_dir: libexecdir,
++  )
++endif
+diff --git a/src/discrete-detection/xe.c b/src/discrete-detection/xe.c
+new file mode 100644
+index 0000000..5ee6ede
+--- /dev/null
++++ b/src/discrete-detection/xe.c
+@@ -0,0 +1,63 @@
++#include <fcntl.h>
++#include <stdint.h>
++#include <locale.h>
++#include <sys/ioctl.h>
++#include <gio/gio.h>
++
++#include <drm/xe_drm.h>
++
++typedef int handle;
++G_DEFINE_AUTO_CLEANUP_FREE_FUNC(handle, close, -1)
++
++int main (int argc, char** argv)
++{
++	const char *devname;
++	g_auto(handle) fd = -1;
++	g_autofree struct drm_xe_query_config *config = NULL;
++	g_autoptr(GOptionContext) option_context = NULL;
++	g_autoptr(GError) error = NULL;
++
++	setlocale (LC_ALL, "");
++	option_context = g_option_context_new ("");
++
++	if (!g_option_context_parse (option_context, &argc, &argv, &error)) {
++		g_print ("Failed to parse arguments: %s\n", error->message);
++		return EXIT_FAILURE;
++	}
++
++	if (argc < 2)
++	{
++		g_print ("%s\n", g_option_context_get_help (option_context, TRUE, NULL));
++		return EXIT_FAILURE;
++	}
++	devname = argv[1];
++
++	fd = open (devname, O_RDWR);
++	if (fd < 0)
++		return EXIT_FAILURE;
++
++	struct drm_xe_device_query query = {
++		.extensions = 0,
++		.query = DRM_XE_DEVICE_QUERY_CONFIG,
++		.size = 0,
++		.data = 0,
++	};
++
++	if (ioctl(fd, DRM_IOCTL_XE_DEVICE_QUERY, &query))
++		return EXIT_FAILURE;
++
++	config = malloc(query.size);
++	if (!config)
++	   return EXIT_FAILURE;
++
++	query.data = (uintptr_t)config;
++	if (ioctl(fd, DRM_IOCTL_XE_DEVICE_QUERY, &query))
++		return EXIT_FAILURE;
++
++	// if the GPU has dedicated vram then its discrrete
++	if (config->info[DRM_XE_QUERY_CONFIG_FLAGS] & DRM_XE_QUERY_CONFIG_FLAG_HAS_VRAM)
++		return EXIT_SUCCESS;
++
++	return EXIT_FAILURE;
++
++}
+-- 
+2.49.0
+
+
+From cefec04bfc28a32bbec1e5a25999a768a6a7bf9c Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Mon, 28 Apr 2025 21:39:48 +0200
+Subject: [PATCH 12/13] tests: fix switcherooctl output test
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ tests/integration-test.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/integration-test.py b/tests/integration-test.py
+index e3dd996..5b4b4bb 100755
+--- a/tests/integration-test.py
++++ b/tests/integration-test.py
+@@ -512,7 +512,7 @@ class Tests(dbusmock.DBusTestCase):
+ 
+         out = subprocess.run([tool_path], capture_output=True)
+         self.assertEqual(out.returncode, 0, "'switcherooctl' call failed")
+-        self.assertEqual(out.stdout, b'Device: 0\n  Name:        Intel\xc2\xae UHD Graphics 620 (Kabylake GT2)\n  Default:     yes\n  Environment: DRI_PRIME=pci-0000_00_02_0\n\nDevice: 1\n  Name:        GM108M [GeForce 930MX]\n  Default:     no\n  Environment: DRI_PRIME=pci-0000_01_00_0\n')
++        self.assertEqual(out.stdout, b'Device: 0\n  Name:        Intel\xc2\xae UHD Graphics 620 (Kabylake GT2)\n  Default:     yes\n  Discrete:    no\n  Environment: DRI_PRIME=pci-0000_00_02_0\n\nDevice: 1\n  Name:        GM108M [GeForce 930MX]\n  Default:     no\n  Discrete:    no\n  Environment: DRI_PRIME=pci-0000_01_00_0\n')
+ 
+         out = subprocess.run([tool_path, 'launch', '--gpu', '0', 'env'], capture_output=True)
+         self.assertEqual(out.returncode, 0, "'switcherooctl launch --gpu 0' failed")
+-- 
+2.49.0
+
+
+From a446971f7aef77218625eb8627ec34e86e403737 Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Mon, 28 Apr 2025 21:53:21 +0200
+Subject: [PATCH 13/13] tests: add tests for xe discrete detection
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ tests/discrete-detection/drm_xe_mock.c | 47 ++++++++++++++++++++++++++
+ tests/discrete-detection/meson.build   | 42 ++++++++++++++++++++++-
+ 2 files changed, 88 insertions(+), 1 deletion(-)
+ create mode 100644 tests/discrete-detection/drm_xe_mock.c
+
+diff --git a/tests/discrete-detection/drm_xe_mock.c b/tests/discrete-detection/drm_xe_mock.c
+new file mode 100644
+index 0000000..a9da460
+--- /dev/null
++++ b/tests/discrete-detection/drm_xe_mock.c
+@@ -0,0 +1,47 @@
++#include <string.h>
++#include <stdint.h>
++#include <stdio.h>
++#include <errno.h>
++
++#include <drm/xe_drm.h>
++enum {
++	OTHER_GPU,
++	INTEL_IGPU,
++	INTEL_GPU,
++};
++
++/* Mock open(2) so we can test multiple devices configurations */
++int open(const char *pathname, int flags)
++{
++	if (!strcmp(pathname, "OTHER_GPU"))
++		return OTHER_GPU;
++	if (!strcmp (pathname, "INTEL_IGPU"))
++		return INTEL_IGPU;
++	if (!strcmp (pathname, "INTEL_GPU"))
++		return INTEL_GPU;
++
++	return -1;
++}
++
++/* open64 may be used for large file support */
++int open64(const char *pathname, int flags)
++{
++	return open (pathname, flags);
++}
++
++int ioctl(int fd, unsigned long op, struct drm_xe_device_query* query)
++{
++	if (op != DRM_IOCTL_XE_DEVICE_QUERY)
++		return EINVAL;
++	if (fd == OTHER_GPU)
++		return ENODEV;
++
++	if (query->size == 0) {
++		query->size = sizeof(struct drm_xe_query_config);
++	} else {
++		struct drm_xe_query_config *config = (struct drm_xe_query_config*)query->data;
++		config->info[DRM_XE_QUERY_CONFIG_FLAGS] = fd == INTEL_GPU ? DRM_XE_QUERY_CONFIG_FLAG_HAS_VRAM : 0;
++	}
++
++	return 0;
++}
+diff --git a/tests/discrete-detection/meson.build b/tests/discrete-detection/meson.build
+index f01a014..998229f 100644
+--- a/tests/discrete-detection/meson.build
++++ b/tests/discrete-detection/meson.build
+@@ -77,4 +77,44 @@ if libdrm.found() and libdrm_nouveau.found()
+         env: environment({'LD_PRELOAD': nouveau_mock_lib.full_path()}),
+         should_fail: false
+     )
+-endif
+\ No newline at end of file
++endif
++
++if drm_xe
++    xe_mock_lib = shared_library(
++        'drm_xe_mock',
++        files('drm_xe_mock.c')
++    )
++
++    test(
++        'test xe detection with invalid device',
++        xe_discrete,
++        args: ['NO_GPU'],
++        env: environment({'LD_PRELOAD': xe_mock_lib.full_path()}),
++        should_fail: true
++    )
++
++    test(
++        'test xe detection with non-Intel GPU',
++        xe_discrete,
++        args: ['OTHER_GPU'],
++        env: environment({'LD_PRELOAD': xe_mock_lib.full_path()}),
++        should_fail: true
++    )
++
++    test(
++        'test xe detection with Intel Integrated GPU',
++        xe_discrete,
++        args: ['INTEL_IGPU'],
++        env: environment({'LD_PRELOAD': xe_mock_lib.full_path()}),
++        should_fail: true
++    )
++
++    test(
++        'test xe detection with Intel Discrete GPU',
++        xe_discrete,
++        args: ['INTEL_GPU'],
++        env: environment({'LD_PRELOAD': xe_mock_lib.full_path()}),
++        should_fail: false
++    )
++
++endif
+-- 
+2.49.0
 

--- a/baseos/switcheroo-control/switcheroo-control.spec
+++ b/baseos/switcheroo-control/switcheroo-control.spec
@@ -1,6 +1,6 @@
 Name:           switcheroo-control
 Version:        2.6
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        D-Bus service to check the availability of dual-GPU
 
 License:        GPLv3
@@ -20,6 +20,7 @@ BuildRequires:  systemd
 BuildRequires:  python3-dbusmock
 BuildRequires:  umockdev
 BuildRequires:  libdrm-devel
+BuildRequires:  kernel-headers
 
 %{?systemd_requires}
 
@@ -69,6 +70,7 @@ fi
 %{_libexecdir}/switcheroo-control
 %{_libexecdir}/check-discrete-amdgpu
 %{_libexecdir}/check-discrete-nouveau
+%{_libexecdir}/check-discrete-xe
 %{_udevhwdbdir}/30-pci-intel-gpu.hwdb
 %{_mandir}/man1/switcherooctl.1*
 %{_udevrulesdir}/30-discrete-gpu.rules
@@ -79,6 +81,9 @@ fi
 %{_datadir}/gtk-doc/html/%{name}/
 
 %changelog
+* Wed Apr 30 2025 Jan200101 <sentrycraft123@gmail.com> - 2.6-8
+- Update discrete patch
+
 * Sat Jan 21 2023 Fedora Release Engineering <releng@fedoraproject.org> - 2.6-3
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_38_Mass_Rebuild
 


### PR DESCRIPTION
Updates the patch to the newest version with the following changes since then:
- update GPU list when update event is send
    - GPU drivers (specifically Nvidia) may load later than switcheroo-control resulting in discrete detection not being done
- xe discrete detection
    - libdrm doesn't have any facilities for the xe driver yet so this is done directly with the kernel