### PR TITLE
chore: Update heroic-games-launcher.spec

### DIFF
--- a/baseos/heroic-games-launcher/heroic-games-launcher.spec
+++ b/baseos/heroic-games-launcher/heroic-games-launcher.spec
@@ -16,7 +16,7 @@
 
 Name:          %{shortname}-games-launcher
 Version:       2.17.2
-Release:       1%?dist
+Release:       2%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com
@@ -37,7 +37,7 @@ Requires:      hicolor-icon-theme
 Requires:      nss
 Requires:      python3
 Requires:      which
-Recommends:    gamemode
+Recommends:    (falcond or gamemode)
 Recommends:    mangohud
 Recommends:    umu-launcher
 Provides:      bundled(comet) = %{comet_version}

--- a/baseos/heroic-games-launcher/heroic-games-launcher.spec
+++ b/baseos/heroic-games-launcher/heroic-games-launcher.spec
@@ -1,11 +1,10 @@
 %global debug_package %{nil}
 %global __provides_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
-%ifnarch aarch64
+%ifnarch aarch64 
 %global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\aarch64*\\.so.*))$
 %elifarch aarch64
 %global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\x86_64*\\.so.*)|(.*\\x86-64*\\.so.*))$
 %endif
-%define _build_id_links none
 %global org_name Heroic-Games-Launcher
 %global git_name %(echo %{org_name} | sed 's/-//g')
 %global reverse_dns com.heroicgameslauncher.hgl
@@ -16,14 +15,14 @@
 %global comet_version 0.2.0
 
 Name:          %{shortname}-games-launcher
-Version:       2.17.0
+Version:       2.17.2
 Release:       1%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com
 BuildRequires: anda-srpm-macros
 BuildRequires: desktop-file-utils
-### Electron builder builds some things with GCC(++), Git, and Make
+# Electron builder builds some things with GCC(++), Git, and Make
 BuildRequires: gcc
 BuildRequires: gcc-c++
 BuildRequires: git
@@ -57,6 +56,7 @@ Heroic is a Free and Open Source Epic, GOG, and Amazon Prime Games launcher for 
 pnpm install
 pnpm run download-helper-binaries
 pnpm dist:linux
+wait
 
 %install
 mkdir -p %{buildroot}%{_datadir}/%{shortname}


### PR DESCRIPTION
Latest changes to Heroic to bump it to 2.17.2.

Mostly cosmetic and a version bump but the `wait` was needed in some build flukes.