### PR TITLE
chore: Update anda-srpm-macros

### DIFF
--- a/baseos/anda-srpm-macros/anda-srpm-macros.spec
+++ b/baseos/anda-srpm-macros/anda-srpm-macros.spec
@@ -1,5 +1,5 @@
 Name:           anda-srpm-macros
-Version:        0.2.17
+Version:        0.2.18
 Release:        1%?dist
 Summary:        SRPM macros for extra Fedora packages
 

--- a/baseos/anda-srpm-macros/anda-srpm-macros.spec
+++ b/baseos/anda-srpm-macros/anda-srpm-macros.spec
@@ -1,5 +1,5 @@
 Name:           anda-srpm-macros
-Version:        0.2.10
+Version:        0.2.17
 Release:        1%?dist
 Summary:        SRPM macros for extra Fedora packages
 
@@ -25,13 +25,16 @@ BuildArch:      noarch
 for file in ./macros.*; do
     install -Dpm644 -t %buildroot%_rpmmacrodir $file
 done
+install -Dpm755 *.sh -t %buildroot%_libexecdir/%name/
 
 %files
+%attr(0755, root, root) %_libexecdir/%name/*.sh
 %{_rpmmacrodir}/macros.anda
 %{_rpmmacrodir}/macros.caching
 %{_rpmmacrodir}/macros.cargo_extra
 %{_rpmmacrodir}/macros.go_extra
 %{_rpmmacrodir}/macros.nim_extra
+%{_rpmmacrodir}/macros.zig_extra
 
 
 %changelog


### PR DESCRIPTION
We have had several bugfix releases recently to address some issues with the scripts and Cargo macros. This also adds the file for our custom Zig macros that were added.