### PR TITLE
update umu-launcher.spec

### DIFF
--- a/baseos/umu-launcher/umu-launcher.spec
+++ b/baseos/umu-launcher/umu-launcher.spec
@@ -10,9 +10,6 @@
 
 %global rel_build 1.%{build_timestamp}.%{shortcommit}%{?dist}
 
-# F41 doesn't ship urllib3 >= 2.0 needed
-%global urllib3 2.3.0
-
 Name:           umu-launcher
 Version:        %{tag}
 Release:        %{rel_build}
@@ -21,7 +18,6 @@ Summary:        A tool for launching non-steam games with proton
 License:        GPLv3
 URL:            https://github.com/Open-Wine-Components/umu-launcher
 Source0:        %{url}/archive/refs/tags/%{tag}.tar.gz#/%{name}-%{tag}.tar.gz
-Source1:        https://github.com/urllib3/urllib3/releases/download/%{urllib3}/urllib3-%{urllib3}.tar.gz
 
 BuildArch:  x86_64
 BuildRequires:  meson >= 0.54.0
@@ -45,44 +41,23 @@ BuildRequires:  python3-xlib
 BuildRequires:  python3-pyzstd
 BuildRequires:  cargo
 
-# Can't use these yet, F41 doesn't ship urllib3 >= 2.0 needed
-#BuildRequires:  python3-urllib3
-
 Requires:	python
 Requires:	python3
 Requires:	python3-xlib
 Requires:	python3-filelock
 Requires:	python3-pyzstd
-
-# Can't use these yet, F41 doesn't ship urllib3 >= 2.0 needed
-#Requires:  python3-urllib3
+Requires:	python3-urllib3
 
 Recommends:	python3-cbor2
 Recommends:	python3-xxhash
 Recommends:	libzstd
 
-# We need this for now to allow umu's builtin urllib3 version to be used.
-# Can be removed when python3-urllib3 version is bumped >= 2.0
-AutoReqProv: no
-
-
 %description
 %{name} A tool for launching non-steam games with proton
 
-%prep
-%autosetup -p 1
-if ! find subprojects/urllib3/ -mindepth 1 -maxdepth 1 | read; then
-    # Directory is empty, perform action
-    mv %{SOURCE1} .
-    tar -xf urllib3-%{urllib3}.tar.gz
-    rm *.tar.gz
-    mv urllib3-%{urllib3}/* subprojects/urllib3/
-fi
-
 %build
 # Update this when fedora ships urllib3 >= 2.0
-#./configure.sh --prefix=/usr --use-system-pyzstd --use-system-urllib
-./configure.sh --prefix=/usr --use-system-pyzstd
+./configure.sh --prefix=/usr --use-system-pyzstd --use-system-urllib
 make
 
 %install


### PR DESCRIPTION
Updates the RPM spec to require Fedora 43's native python3-urllib3 package. See https://packages.fedoraproject.org/pkgs/python-urllib3/python3-urllib3/fedora-43.html.
