### PR TITLE
bump falcond, implement falcond group

### DIFF
--- a/baseos/falcond/falcond-gui/falcond-gui.spec
+++ b/baseos/falcond/falcond-gui/falcond-gui.spec
@@ -1,5 +1,5 @@
 Name:           falcond-gui
-Version:        1.0.0
+Version:        1.0.1
 Release:        %autorelease
 Summary:        A GTK4/LibAdwaita application to control and monitor the Falcond gaming optimization daemon.
 
@@ -55,5 +55,8 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/512x512/apps/falcond.png
 
 %changelog
+* Mon Jan 12 2026 LionHeartP <LionHeartP@proton.me> - 1.0.1-1
+- Update to 1.0.1
+
 * Thu Jan 01 2026 LionHeartP <LionHeartP@proton.me> - 1.0.0-1
 - Initial package for falcond-gui

--- a/baseos/falcond/falcond-profiles/falcond-profiles.spec
+++ b/baseos/falcond/falcond-profiles/falcond-profiles.spec
@@ -1,14 +1,14 @@
 %global debug_package %{nil}
 Name:           falcond-profiles
 Version:        1.0
-Release:        %autorelease -b9
+Release:        %autorelease -b10
 Summary:        Advanced Linux Gaming Performance Daemon
 
 License:        MIT
 URL:            https://github.com/PikaOS-Linux/%{name}/
 Source0:        %{url}/archive/refs/heads/main.tar.gz
 
-ExclusiveArch:	x86_64
+BuildArch:      noarch
 
 BuildRequires:  tar
 
@@ -25,24 +25,22 @@ falcond is a powerful system daemon designed to automatically optimize your Linu
 %build
 
 %install
-mkdir -p %{buildroot}%{_datadir}/falcond/
-mkdir -p %{buildroot}%{_datadir}/falcond/profiles/
-mkdir -p %{buildroot}%{_datadir}/falcond/profiles/handheld/
-mkdir -p %{buildroot}%{_datadir}/falcond/profiles/htpc/
-mkdir -p %{buildroot}%{_datadir}/falcond/profiles/user/
-cp -a usr/share/falcond/system.conf %{buildroot}%{_datadir}/falcond/
-cp -a usr/share/falcond/profiles/* %{buildroot}%{_datadir}/falcond/profiles/
-cp -a usr/share/falcond/profiles/handheld/* %{buildroot}%{_datadir}/falcond/profiles/handheld/
-cp -a usr/share/falcond/profiles/htpc/* %{buildroot}%{_datadir}/falcond/profiles/htpc/
-    
+install -Dm644 usr/share/falcond/system.conf -t %{buildroot}%{_datadir}/falcond/
+install -Dm644 usr/share/falcond/profiles/*.conf -t %{buildroot}%{_datadir}/falcond/profiles/
+install -Dm644 usr/share/falcond/profiles/handheld/* -t %{buildroot}%{_datadir}/falcond/profiles/handheld/
+install -Dm644 usr/share/falcond/profiles/htpc/* -t %{buildroot}%{_datadir}/falcond/profiles/htpc/
+
+install -dm2755 %{buildroot}%{_datadir}/falcond/profiles/user
+
 %files
 %doc README.md
 %license LICENSE
-%{_datadir}/falcond/system.conf
-%{_datadir}/falcond/profiles/*.conf
-%{_datadir}/falcond/profiles/handheld/*.conf
-%{_datadir}/falcond/profiles/htpc/*.conf
-%attr(0777, root, root) %dir %{_datadir}/falcond/profiles/user/
+%dir %{_datadir}/falcond
+%config %{_datadir}/falcond/system.conf
+%config %{_datadir}/falcond/profiles/*.conf
+%config %{_datadir}/falcond/profiles/handheld/*.conf
+%config %{_datadir}/falcond/profiles/htpc/*.conf
+%attr(2755, root, falcond) %dir %{_datadir}/falcond/profiles/user
 
 %changelog
 %autochangelog

--- a/baseos/falcond/falcond-profiles/falcond-profiles.spec
+++ b/baseos/falcond/falcond-profiles/falcond-profiles.spec
@@ -30,7 +30,7 @@ install -Dm644 usr/share/falcond/profiles/*.conf -t %{buildroot}%{_datadir}/falc
 install -Dm644 usr/share/falcond/profiles/handheld/* -t %{buildroot}%{_datadir}/falcond/profiles/handheld/
 install -Dm644 usr/share/falcond/profiles/htpc/* -t %{buildroot}%{_datadir}/falcond/profiles/htpc/
 
-install -dm2755 %{buildroot}%{_datadir}/falcond/profiles/user
+install -dm2775 %{buildroot}%{_datadir}/falcond/profiles/user
 
 %files
 %doc README.md
@@ -40,7 +40,7 @@ install -dm2755 %{buildroot}%{_datadir}/falcond/profiles/user
 %config %{_datadir}/falcond/profiles/*.conf
 %config %{_datadir}/falcond/profiles/handheld/*.conf
 %config %{_datadir}/falcond/profiles/htpc/*.conf
-%attr(2755, root, falcond) %dir %{_datadir}/falcond/profiles/user
+%attr(2775, root, falcond) %dir %{_datadir}/falcond/profiles/user
 
 %changelog
 %autochangelog

--- a/baseos/falcond/falcond-profiles/falcond-profiles.spec
+++ b/baseos/falcond/falcond-profiles/falcond-profiles.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 Name:           falcond-profiles
 Version:        1.0
-Release:        %autorelease -b10
+Release:        %autorelease -b11
 Summary:        Advanced Linux Gaming Performance Daemon
 
 License:        MIT
@@ -36,10 +36,10 @@ install -dm2775 %{buildroot}%{_datadir}/falcond/profiles/user
 %doc README.md
 %license LICENSE
 %dir %{_datadir}/falcond
-%config %{_datadir}/falcond/system.conf
-%config %{_datadir}/falcond/profiles/*.conf
-%config %{_datadir}/falcond/profiles/handheld/*.conf
-%config %{_datadir}/falcond/profiles/htpc/*.conf
+%{_datadir}/falcond/system.conf
+%{_datadir}/falcond/profiles/*.conf
+%{_datadir}/falcond/profiles/handheld/*.conf
+%{_datadir}/falcond/profiles/htpc/*.conf
 %attr(2775, root, falcond) %dir %{_datadir}/falcond/profiles/user
 
 %changelog

--- a/baseos/falcond/falcond.spec
+++ b/baseos/falcond/falcond.spec
@@ -2,8 +2,8 @@
 %global debug_package %{nil}
 
 Name:           falcond
-Version:        1.2.1
-Release:        %autorelease -b2
+Version:        1.2.2
+Release:        %autorelease
 Summary:        Advanced Linux Gaming Performance Daemon
 
 License:        MIT
@@ -20,6 +20,8 @@ Recommends:	%{name}-gui
 Requires:	%{name}-profiles
 Requires:	%{name}-gui
 Requires:	scx-scheds
+
+Provides:       group(falcond)
 
 %description
 falcond is a powerful system daemon designed to automatically optimize your Linux gaming experience. It intelligently manages system resources and performance settings on a per-game basis, eliminating the need to manually configure settings for each game.
@@ -39,6 +41,13 @@ zig build \
     -Doptimize=ReleaseFast \
     -Dcpu=x86_64_v2
     
+%pre
+# Create falcond group if it doesn't exist
+getent group 'falcond' >/dev/null || groupadd -f -r 'falcond' || :
+
+# Root must be a member of the group
+usermod -aG 'falcond' root || :
+    
 %post
 %systemd_post %{name}.service
 
@@ -55,6 +64,10 @@ zig build \
 %{_unitdir}/%{name}.service
 
 %changelog
+* Sat Jan 03 2026 LionHeartP <LionHeartP@proton.me> - 1.2.2-1
+- Update to 1.2.2
+- Implement falcond group for profile editing
+
 * Thu Jan 01 2026 LionHeartP <LionHeartP@proton.me> - 1.2.1-1
 - Update to 1.2.1
 

--- a/baseos/falcond/falcond.spec
+++ b/baseos/falcond/falcond.spec
@@ -2,7 +2,7 @@
 %global debug_package %{nil}
 
 Name:           falcond
-Version:        1.2.2
+Version:        1.2.3
 Release:        %autorelease
 Summary:        Advanced Linux Gaming Performance Daemon
 
@@ -64,6 +64,9 @@ usermod -aG 'falcond' root || :
 %{_unitdir}/%{name}.service
 
 %changelog
+* Tue Jan 06 2026 LionHeartP <LionHeartP@proton.me> - 1.2.3-1
+- Update to 1.2.3
+
 * Sat Jan 03 2026 LionHeartP <LionHeartP@proton.me> - 1.2.2-1
 - Update to 1.2.2
 - Implement falcond group for profile editing


### PR DESCRIPTION
Implement falcond group in order to access the user profiles directory for security reasons as proposed by Roachy and Ferreo.

Additionally, thanks to @GildedRoach for packaging and testing.