### PR TITLE
bump: anda-srpm-macros

### DIFF
--- a/baseos/anda-srpm-macros/anda-srpm-macros.spec
+++ b/baseos/anda-srpm-macros/anda-srpm-macros.spec
@@ -1,5 +1,5 @@
 Name:           anda-srpm-macros
-Version:        0.3.3
+Version:        0.3.4
 Release:        1%?dist
 Summary:        SRPM macros for extra Fedora packages
 

--- a/baseos/anda-srpm-macros/anda-srpm-macros.spec
+++ b/baseos/anda-srpm-macros/anda-srpm-macros.spec
@@ -42,6 +42,9 @@ install -Dpm755 *.sh -t %buildroot%_libexecdir/%name/
 %{_rpmmacrodir}/macros.webapps
 
 %changelog
+* Sun Mar 15 2026 Owen Zimmerman <owen@fyralabs.com> - 0.3.4-1
+- Bump to 0.3.4
+
 * Wed Aug 14 2024 madonuko <mado@fyralabs.com> - 0.1.7-2
 - Move sources outside of packages repo
 


### PR DESCRIPTION
This update tweaks the `%git_clone` macro a bit, and adds new cargo macros