### PR TITLE
Fix: create ~/.config directory before copying starship.toml

### DIFF
--- a/baseos/starship/nobara_profile_starship.sh
+++ b/baseos/starship/nobara_profile_starship.sh
@@ -1,10 +1,11 @@
 if test "$BASH"; then
-  if command -v starship &>/dev/null; then
-    if [ ! -f $HOME/.config/starship.toml ]; then
-        if [ -f /usr/share/starship/starship.toml ]; then
-            cp /usr/share/starship/starship.toml $HOME/.config/
+    if command -v starship &>/dev/null; then
+        if [ ! -f $HOME/.config/starship.toml ]; then
+            if [ -f /usr/share/starship/starship.toml ]; then
+                mkdir -p $HOME/.config
+                cp /usr/share/starship/starship.toml $HOME/.config/
+            fi
         fi
     fi
     eval "$(starship init bash)"
-  fi
 fi


### PR DESCRIPTION
The current initialization script checks if $HOME/.config/starship.toml exists. If it does not, it attempts to copy the default config file from /usr/share/starship/starship.toml directly to $HOME/.config/.

However, on pristine or newly provisioned user environments where the $HOME/.config directory has not yet been initialized, the `cp` command fails with a "No such file or directory" error because the destination directory path itself does not exist.

This patch adds an explicit `mkdir -p $HOME/.config` safety check before executing the copy command, ensuring the target folder structure is present and preventing the copy failure.